### PR TITLE
fix(scripts): Add --nogetbinpkg command line option

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -16,6 +16,8 @@ DEFINE_string board "${DEFAULT_BOARD}" \
   "The board to build packages for."
 DEFINE_boolean usepkg "${FLAGS_TRUE}" \
   "Use binary packages to bootstrap when possible."
+DEFINE_boolean getbinpkg "${FLAGS_TRUE}" \
+  "Download binary packages from remote repository."
 DEFINE_boolean noworkon "${FLAGS_FALSE}" \
   "Don't force-build workon packages."
 DEFINE_boolean showoutput "${FLAGS_FALSE}" \
@@ -100,6 +102,11 @@ else
 fi
 if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
   UPDATE_ARGS+=( --usepkg )
+  if [[ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]]; then
+    UPDATE_ARGS+=( --getbinpkg )
+  else
+    UPDATE_ARGS+=( --nogetbinpkg )
+  fi
 else
   UPDATE_ARGS+=( --nousepkg )
 fi
@@ -140,7 +147,10 @@ if [[ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ||
   # Use binary packages. Include all build-time dependencies,
   # so as to avoid unnecessary differences between source
   # and binary builds.
-  EMERGE_FLAGS+=( --getbinpkg --usepkg --with-bdeps y )
+  EMERGE_FLAGS+=( --usepkg --with-bdeps y )
+  if [[ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]]; then
+      EMERGE_FLAGS+=( --getbinpkg )
+  fi
 fi
 
 if [[ "${FLAGS_jobs}" -ne -1 ]]; then

--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -36,6 +36,8 @@ assert_root_user
 DEFINE_string chroot "$DEFAULT_CHROOT_DIR" \
   "Destination dir for the chroot environment."
 DEFINE_boolean usepkg $FLAGS_TRUE "Use binary packages to bootstrap."
+DEFINE_boolean getbinpkg $FLAGS_TRUE \
+  "Download binary packages from remote repository."
 DEFINE_boolean delete $FLAGS_FALSE "Delete an existing chroot."
 DEFINE_boolean replace $FLAGS_FALSE "Overwrite existing chroot, if any."
 DEFINE_integer jobs -1 "How many packages to build in parallel at maximum."
@@ -79,7 +81,10 @@ if [[ $FLAGS_usepkg -eq $FLAGS_TRUE ]]; then
   # Use binary packages. Include all build-time dependencies,
   # so as to avoid unnecessary differences between source
   # and binary builds.
-  USEPKG="--getbinpkg --usepkg --with-bdeps y"
+  USEPKG="--usepkg --with-bdeps y"
+  if [[ $FLAGS_getbinpkg -eq $FLAGS_TRUE ]]; then
+    USEPKG="$USEPKG --getbinpkg"
+  fi
 fi
 
 # Support faster build if necessary.
@@ -464,6 +469,8 @@ early_enter_chroot $EMERGE_CMD -uNv crossdev
 TOOLCHAIN_ARGS=( --deleteold )
 if [[ ${FLAGS_usepkg} -eq ${FLAGS_FALSE} ]]; then
   TOOLCHAIN_ARGS+=( --nousepkg )
+elif [[ ${FLAGS_getbinpkg} -eq ${FLAGS_FALSE} ]]; then
+  TOOLCHAIN_ARGS+=( --nogetbinpkg )
 fi
 # Note: early_enter_chroot executes as root.
 early_enter_chroot "${CHROOT_TRUNK_DIR}/chromite/bin/cros_setup_toolchains" \
@@ -498,6 +505,11 @@ fi
 UPDATE_ARGS=( --skip_toolchain_update )
 if [[ ${FLAGS_usepkg} -eq ${FLAGS_TRUE} ]]; then
   UPDATE_ARGS+=( --usepkg )
+  if [[ ${FLAGS_getbinpkg} -eq ${FLAGS_TRUE} ]]; then
+    UPDATE_ARGS+=( --getbinpkg )
+  else
+    UPDATE_ARGS+=( --nogetbinpkg )
+  fi
 else
   UPDATE_ARGS+=( --nousepkg )
 fi

--- a/setup_board
+++ b/setup_board
@@ -21,6 +21,8 @@ DEFINE_boolean force $FLAGS_FALSE \
   "Force re-creating board root."
 DEFINE_boolean usepkg $FLAGS_TRUE \
   "Use binary packages to bootstrap."
+DEFINE_boolean getbinpkg $FLAGS_TRUE \
+  "Download binary packages from remote repository."
 
 FLAGS_HELP="usage: $(basename $0) [flags]
 
@@ -280,6 +282,11 @@ else
 fi
 if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
   UPDATE_ARGS+=" --usepkg"
+  if [[ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]]; then
+    UPDATE_ARGS+=" --getbinpkg "
+  else
+    UPDATE_ARGS+=" --nogetbinpkg "
+  fi
 else
   UPDATE_ARGS+=" --nousepkg"
 fi
@@ -514,7 +521,10 @@ else
     KERNEL_EMERGE_FLAGS="--select --quiet --root-deps=rdeps"
     if [[ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ||
           "${FLAGS_reuse_pkgs_from_local_boards}" -eq "${FLAGS_TRUE}" ]]; then
-      KERNEL_EMERGE_FLAGS+=" --getbinpkg --usepkg"
+      KERNEL_EMERGE_FLAGS+=" --usepkg"
+      if [[ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]]; then
+        KERNEL_EMERGE_FLAGS+=" --getbinpkg "
+      fi
     fi
 
     sudo -E "${EMERGE_WRAPPER}" ${KERNEL_EMERGE_FLAGS} \

--- a/update_chroot
+++ b/update_chroot
@@ -16,6 +16,8 @@ assert_not_root_user
 # Developer-visible flags.
 DEFINE_boolean usepkg $FLAGS_TRUE \
   "Use binary packages to bootstrap."
+DEFINE_boolean getbinpkg $FLAGS_TRUE \
+  "Download binary packages from remote repository."
 
 FLAGS_HELP="usage: $(basename $0) [flags]
 Performs an update of the chroot. This script is called as part of
@@ -62,7 +64,10 @@ info "Updating chroot"
 
 EMERGE_FLAGS="-uNv --with-bdeps=y --select"
 if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
-  EMERGE_FLAGS="${EMERGE_FLAGS} --getbinpkg"
+  EMERGE_FLAGS="${EMERGE_FLAGS} --usepkg"
+  if [ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]; then
+    EMERGE_FLAGS="${EMERGE_FLAGS} --getbinpkg"
+  fi
 
   # Only update toolchain when binpkgs are available. Toolchain rollout
   # process only takes place when the chromiumos sdk builder finishes
@@ -93,6 +98,8 @@ if [ "${FLAGS_skip_toolchain_update}" -eq "${FLAGS_FALSE}" ]; then
   # This should really only be skipped while bootstrapping.
   if [ "${FLAGS_usepkg}" -eq "${FLAGS_FALSE}" ]; then
     TOOLCHAIN_FLAGS+=( --nousepkg )
+  elif [ "${FLAGS_getbinpkg}" -eq "${FLAGS_FALSE}" ]; then
+    TOOLCHAIN_FLAGS+=( --nogetbinpkg )
   fi
   # Expand the path before sudo, as root doesn't have the same path magic.
   sudo -E $(type -p cros_setup_toolchains) "${TOOLCHAIN_FLAGS[@]}"


### PR DESCRIPTION
As-is all of the various emerge wrapping scripts default to using
--getbinpkg whenever --usepkg is enabled. This means every single emerge
command made makes multiple synchronous HTTP requests to the upstream
binary package repository to get the latest package list. This gets
really frustrating when working remotely with limited network
connectivity. Using --usepkg with --nogetbinpkg will use locally cached
packages without making remote requests.
