### PR TITLE
fix(update_ebuilds): Move misplaced command

### DIFF
--- a/update_ebuilds
+++ b/update_ebuilds
@@ -69,8 +69,8 @@ bump($1): sync with upstream
 Packages updated:
 $(for p in "$@"; do echo "  $p"; done | sort)
 EOF
+        git commit -e -F .git/COMMIT_EDITMSG
     fi
-    git commit -e -F .git/COMMIT_EDITMSG
 else
     git status
 fi


### PR DESCRIPTION
The big here document in the middle of a if statement confuses the code
layout some and I put the git commit outside of the else clause instead
of inside. Ooops. The joy of shell.
