### PR TITLE
add(master_release): Add script for updating master's version.txt

### DIFF
--- a/branch_release
+++ b/branch_release
@@ -7,9 +7,6 @@
 SCRIPT_ROOT=$(dirname $(readlink -f "$0"))
 . "${SCRIPT_ROOT}/common.sh" || exit 1
 
-COREOS_EPOCH=1372636800  # Mon Jul  1 00:00:00 UTC 2013
-TODAYS_VERSION=$(( (`date +%s` - ${COREOS_EPOCH}) / 86400 ))
-
 DEFINE_integer build "${TODAYS_VERSION}" \
     "Branch name (aka 'build'), should be days since 2013-7-1"
 DEFINE_integer branch 0 "Branch revision, should be 0"

--- a/common.sh
+++ b/common.sh
@@ -315,6 +315,12 @@ fi
 # Full version string.
 COREOS_VERSION_STRING="${COREOS_BUILD}.${COREOS_BRANCH}.${COREOS_PATCH}"
 
+# Calculate what today's build version should be, used by release
+# scripts to provide a reasonable default value. The value is the number
+# of days since COREOS_EPOCH, Mon Jul  1 00:00:00 UTC 2013
+readonly COREOS_EPOCH=1372636800
+TODAYS_VERSION=$(printf "%04d" $(( (`date +%s` - ${COREOS_EPOCH}) / 86400 )) )
+
 # Load developer's custom settings.  Default location is in scripts dir,
 # since that's available both inside and outside the chroot.  By convention,
 # settings from this file are variables starting with 'CHROMEOS_'

--- a/master_release
+++ b/master_release
@@ -7,10 +7,6 @@
 SCRIPT_ROOT=$(dirname $(readlink -f "$0"))
 . "${SCRIPT_ROOT}/common.sh" || exit 1
 
-COREOS_EPOCH=1372636800  # Mon Jul  1 00:00:00 UTC 2013
-TODAYS_VERSION=$(( (`date +%s` - ${COREOS_EPOCH}) / 86400 ))
-TODAYS_VERSION=$(printf "%04d" "${TODAYS_VERSION}")
-
 DEFINE_string master "master" "Manifest master branch to update."
 DEFINE_string branch "build-${TODAYS_VERSION}" \
     "Manifest branch, tag, or other ref to get version from."


### PR DESCRIPTION
This is intended to be called after branch_release and all official
builds from that new branch are complete. Then updating master's
version.txt will switch things to start using that new release as the
source for binary packages.

Complete documentation for this whole process coming soon. :)
