### PR TITLE
fix(build_image): print out image_to_vm for dev image

### DIFF
--- a/build_image
+++ b/build_image
@@ -212,6 +212,7 @@ if should_build_image ${CHROMEOS_BASE_IMAGE_NAME}; then
 fi
 if should_build_image ${CHROMEOS_DEVELOPER_IMAGE_NAME}; then
   echo "Developer image created as ${CHROMEOS_DEVELOPER_IMAGE_NAME}"
+  print_image_to_vm
 fi
 if should_build_image ${CHROMEOS_TEST_IMAGE_NAME}; then
   echo "Test image created as ${CHROMEOS_TEST_IMAGE_NAME}"


### PR DESCRIPTION
this broke accidently in a previous commit. Fix it by printing the
instructions to build a vm again.
