### PR TITLE
fix(build_library): disable upload by default

### DIFF
--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -4,17 +4,14 @@
 
 GSUTIL_OPTS=
 UPLOAD_ROOT="gs://storage.core-os.net/coreos"
-UPLOAD_DEFAULT=${FLAGS_FALSE}
-if [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
-  UPLOAD_DEFAULT=${FLAGS_TRUE}
-fi
+
 
 IMAGE_ZIPPER="lbzip2 --compress --keep"
 IMAGE_ZIPEXT=".bz2"
 
 DEFINE_boolean parallel ${FLAGS_TRUE} \
   "Enable parallelism in gsutil."
-DEFINE_boolean upload ${UPLOAD_DEFAULT} \
+DEFINE_boolean upload ${FLAGS_FALSE} \
   "Upload all packages/images via gsutil."
 
 check_gsutil_opts() {


### PR DESCRIPTION
If you are just testing out official builds it is a bit weird that
building an image also uploads it. Make the build system specify upload;
don't make the developer specify --noupload.
