### PR TITLE
fix(common): Adopt semver formatted version strings.

### DIFF
--- a/branch_release
+++ b/branch_release
@@ -20,8 +20,6 @@ FLAGS "$@" || exit 1
 eval set -- "${FLAGS_ARGV}"
 switch_to_strict_mode
 
-# Make sure we pad with 0s for a consistent look
-FLAGS_build=$(printf "%04d" "${FLAGS_build}")
 BRANCH_NAME="build-${FLAGS_build}"
 TAG_NAME="v${FLAGS_build}.${FLAGS_branch}.${FLAGS_patch}"
 

--- a/common.sh
+++ b/common.sh
@@ -311,8 +311,9 @@ fi
 source "$COREOS_VERSION_FILE" || die "Cannot source version.txt"
 
 # Official builds must set COREOS_OFFICIAL=1 to use an official version.
+# Unofficial builds always appended the date/time as a build identifier.
 if [ ${COREOS_OFFICIAL:-0} -ne 1 ]; then
-  COREOS_PATCH=$(date +%Y_%m_%d_%H%M)
+  COREOS_PATCH="${COREOS_PATCH}+$(date +%Y-%m-%d-%H%M)"
 fi
 
 # Full version string.
@@ -322,7 +323,7 @@ COREOS_VERSION_STRING="${COREOS_BUILD}.${COREOS_BRANCH}.${COREOS_PATCH}"
 # scripts to provide a reasonable default value. The value is the number
 # of days since COREOS_EPOCH, Mon Jul  1 00:00:00 UTC 2013
 readonly COREOS_EPOCH=1372636800
-TODAYS_VERSION=$(printf "%04d" $(( (`date +%s` - ${COREOS_EPOCH}) / 86400 )) )
+TODAYS_VERSION=$(( (`date +%s` - ${COREOS_EPOCH}) / 86400 ))
 
 # Load developer's custom settings.  Default location is in scripts dir,
 # since that's available both inside and outside the chroot.  By convention,


### PR DESCRIPTION
Drop zero padding and format versions as described by the semver spec.
The terminology is a little awkward because we inherited the backwards
meaning of 'BUILD' and 'BRANCH' version identifiers but that the version
strings themselves conform to semver.

(This doesn't change the current version, that'll happen with our next
branch cut)
