### PR TITLE
hack(build_image): Make check for /usr/share/locale a warning.

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -33,8 +33,11 @@ test_image_content() {
   )
   for dir in "${blacklist_dirs[@]}"; do
     if [ -d "$dir" ]; then
-      error "test_image_content: Blacklisted directory found: $dir"
-      returncode=1
+      warn "test_image_content: Blacklisted directory found: $dir"
+      # Only a warning for now, size isn't important enough to kill time
+      # playing whack-a-mole on things like this this yet.
+      #error "test_image_content: Blacklisted directory found: $dir"
+      #returncode=1
     fi
   done
 


### PR DESCRIPTION
Switching the toolchain to upstream Gentoo brought this directory back
and based on the Chromium OS history keeping this directory out of the
builds is a bit tedious. Keeping image sizes down isn't _that_ important
right now so just let it be.
