### PR TITLE
feat(build_image): official lsb-release on prod images

### DIFF
--- a/bin/cros_make_image_bootable
+++ b/bin/cros_make_image_bootable
@@ -110,6 +110,9 @@ DEFINE_string keys_dir "/usr/share/vboot/devkeys" \
 DEFINE_string au_key "" \
   "Filename of the au_key to install"
 
+DEFINE_boolean official_lsb_release ${FLAGS_FALSE} \
+  "Install the official lsb-release"
+
 DEFINE_string rootfs_mountpoint "/tmp/rootfs" \
   "Path where the rootfs can be safely mounted"
 DEFINE_string statefulfs_mountpoint "/tmp/statefulfs" \
@@ -185,6 +188,12 @@ make_image_bootable() {
 
   legacy_offset_size_export ${image}
 
+  if [ ${FLAGS_official_lsb_release} -eq ${FLAGS_TRUE} ]; then
+    # Set /etc/lsb-release on the image.
+    COREOS_OFFICIAL=1 "${BUILD_LIBRARY_DIR}/set_lsb_release" \
+      --root="${FLAGS_rootfs_mountpoint}" \
+      --board="${BOARD}"
+  fi
 
   # Install an auto update key on the root before sealing it off
   if [ ! -z "${FLAGS_au_key}" ]; then

--- a/build_image
+++ b/build_image
@@ -172,6 +172,7 @@ if should_build_image ${COREOS_PRODUCTION_IMAGE_NAME}; then
   ${SCRIPTS_DIR}/bin/cros_make_image_bootable \
     "${BUILD_DIR}" \
      ${COREOS_PRODUCTION_IMAGE_NAME} \
+    --official_lsb_release \
     --au_key=${SRC_ROOT}/third_party/coreos-overlay/coreos-base/coreos-au-key/files/update-payload-key.pub.pem
 
   upload_image "${BUILD_DIR}/${COREOS_PRODUCTION_IMAGE_NAME}"


### PR DESCRIPTION
The /etc/lsb-release should have official values on the prod image. That
way someone can ping the official api.core-os.net with this image.
