### PR TITLE
feat(build_library): reintroduce A/B menu.lst

### DIFF
--- a/build_library/create_legacy_bootloader_templates.sh
+++ b/build_library/create_legacy_bootloader_templates.sh
@@ -72,21 +72,32 @@ if [[ "${FLAGS_arch}" = "x86" || "${FLAGS_arch}" = "amd64"  ]]; then
   cat <<EOF | sudo dd of="${GRUB_DIR}/menu.lst.A" 2>/dev/null
 timeout         0
 
+title           CoreOS A Kernel
+root            (hd0,0)
+kernel          /syslinux/vmlinuz.A ${common_args} root=gptprio: cros_legacy
+
+title           CoreOS B Kernel
+root            (hd0,0)
+kernel          /syslinux/vmlinuz.B ${common_args} root=gptprio: cros_legacy
+
 title           CoreOS bootengine
 root            (hd0,0)
 kernel          /syslinux/vmlinuz-boot_kernel ${common_args} root=gptprio: cros_legacy
 
-title           CoreOS A
+title           CoreOS A Root Rescue
 root            (hd0,0)
 kernel          /syslinux/vmlinuz.A ${common_args} root=${ROOTA} cros_legacy
 
-title           CoreOS B
+title           CoreOS B Root Rescue
 root            (hd0,0)
 kernel          /syslinux/vmlinuz.B ${common_args} root=${ROOTB} cros_legacy
 EOF
   info "Emitted ${GRUB_DIR}/menu.lst.A"
 
-  sudo cp ${GRUB_DIR}/menu.lst.A ${GRUB_DIR}/menu.lst.B
+  cat <<EOF | sudo dd of="${GRUB_DIR}/menu.lst.B" 2>/dev/null
+default         1
+EOF
+  sudo sh -c "cat ${GRUB_DIR}/menu.lst.A >> ${GRUB_DIR}/menu.lst.B"
   info "Emitted ${GRUB_DIR}/menu.lst.B"
   sudo cp ${GRUB_DIR}/menu.lst.A ${GRUB_DIR}/menu.lst
 


### PR DESCRIPTION
reintroduce unique A/B menu.lsts to work around the kexec problems that
we have. Essentially instead of always using boot_kernel on pvgrub
systems use the A/B kernels installed at update time to the boot
partition.
