### PR TITLE
fix(enter_chroot): Limit sharing system mount sharing

### DIFF
--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -242,6 +242,12 @@ setup_env() {
 
     debug "Mounting chroot environment."
     MOUNT_CACHE=$(echo $(awk '{print $2}' /proc/mounts))
+
+    # The cros_sdk script created a new filesystem namespace but the system
+    # default (namely on systemd hosts) may be for everything to be shared.
+    # Using 'slave' means we see global changes but cannot change global state.
+    mount --make-rslave /
+
     setup_mount none "-t proc" /proc
     setup_mount none "-t sysfs" /sys
     setup_mount /dev "--bind" /dev


### PR DESCRIPTION
The existing code seems to assume that the mounts inherited from the
system are private, the Linux default. However on our systems that
clearly isn't the case, all system mounts are set as shared. Considering
all of us have been have been seeing mounts leak out of the SDK despite
cros_sdk creating a new filesystem namespace via unshare I'm guessing
this is a systemd thing.

Instead force all system mounts to 'slave' mode in the SDK namespace so
global changes are still visible but no SDK mounts can leak out.
