### PR TITLE
fix(set_lsb_release): Add option for production updates, misc updates.

### DIFF
--- a/bin/cros_make_image_bootable
+++ b/bin/cros_make_image_bootable
@@ -110,8 +110,8 @@ DEFINE_string keys_dir "/usr/share/vboot/devkeys" \
 DEFINE_string au_key "" \
   "Filename of the au_key to install"
 
-DEFINE_boolean official_lsb_release ${FLAGS_FALSE} \
-  "Install the official lsb-release"
+DEFINE_string production_track "" \
+    "Use production values and a given track for update service."
 
 DEFINE_string rootfs_mountpoint "/tmp/rootfs" \
   "Path where the rootfs can be safely mounted"
@@ -188,9 +188,10 @@ make_image_bootable() {
 
   legacy_offset_size_export ${image}
 
-  if [ ${FLAGS_official_lsb_release} -eq ${FLAGS_TRUE} ]; then
-    # Set /etc/lsb-release on the image.
-    COREOS_OFFICIAL=1 "${BUILD_LIBRARY_DIR}/set_lsb_release" \
+  if [ -n "${FLAGS_production_track}" ]; then
+    # Replace /etc/lsb-release on the image.
+    "${BUILD_LIBRARY_DIR}/set_lsb_release" \
+      --production_track="${FLAGS_production_track}" \
       --root="${FLAGS_rootfs_mountpoint}" \
       --board="${BOARD}"
   fi

--- a/build_image
+++ b/build_image
@@ -172,7 +172,7 @@ if should_build_image ${COREOS_PRODUCTION_IMAGE_NAME}; then
   ${SCRIPTS_DIR}/bin/cros_make_image_bootable \
     "${BUILD_DIR}" \
      ${COREOS_PRODUCTION_IMAGE_NAME} \
-    --official_lsb_release \
+    --production_track="dev-channel" \
     --au_key=${SRC_ROOT}/third_party/coreos-overlay/coreos-base/coreos-au-key/files/update-payload-key.pub.pem
 
   upload_image "${BUILD_DIR}/${COREOS_PRODUCTION_IMAGE_NAME}"

--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -10,55 +10,64 @@
 SCRIPT_ROOT=$(readlink -f $(dirname "$0")/..)
 . "${SCRIPT_ROOT}/common.sh" || exit 1
 
+PRODUCTION_DEFAULT=
+if [[ "${COREOS_OFFICIAL:-0}" -eq 1 ]]; then
+  PRODUCTION_DEFAULT="dev-channel"
+fi
+
 # Flags
 DEFINE_string board "" "The board to build an image for."
 DEFINE_string root "" "The root file system to write /etc/lsb-release to."
+DEFINE_string production_track "${PRODUCTION_DEFAULT}" \
+    "Use production values and a given track for update service."
 
 # Parse command line
 FLAGS "$@" || exit 1
 eval set -- "${FLAGS_ARGV}"
 
-set -e
+switch_to_strict_mode
 
 ROOT_FS_DIR="$FLAGS_root"
 [ -n "$ROOT_FS_DIR" ] || die "--root is required."
 [ -d "$ROOT_FS_DIR" ] || die "Root FS does not exist? ($ROOT_FS_DIR)"
 
 COREOS_VERSION_NAME="CoreOS"
-COREOS_VERSION_AUSERVER=\
-${COREOS_VERSION_AUSERVER:-"http://$(hostname --fqdn):8080/update"}
-COREOS_VERSION_DEVSERVER=\
-${COREOS_VERSION_DEVSERVER:-"http://$(hostname --fqdn):8080"}
-
-# Official builds must set COREOS_OFFICIAL=1.
-if [ ${COREOS_OFFICIAL:-0} = 1 ]; then
-  # Official builds (i.e., buildbot)
-  COREOS_VERSION_TRACK="dev-channel"
-  COREOS_VERSION_NAME="CoreOS"
+if [[ -n "${FLAGS_production_track}" ]]; then
+  COREOS_VERSION_TRACK="${FLAGS_production_track}"
   COREOS_VERSION_DESCRIPTION="${COREOS_VERSION_STRING} (Official Build) \
 ${COREOS_VERSION_TRACK} $FLAGS_board test"
   COREOS_VERSION_AUSERVER="https://api.core-os.net/v1/update/"
   COREOS_VERSION_DEVSERVER=""
-elif [ "$USER" = "chrome-bot" ]; then
-  # Continuous builder
-  COREOS_VERSION_TRACK="buildbot-build"
-  COREOS_VERSION_DESCRIPTION="${COREOS_VERSION_STRING} (Continuous Build \
-- Builder: ${BUILDBOT_BUILD:-"N/A"}) $FLAGS_board"
 else
   # Developer hand-builds
   COREOS_VERSION_TRACK=${COREOS_VERSION_TRACK:-"developer-build"}
   COREOS_VERSION_DESCRIPTION="${COREOS_VERSION_STRING} (Developer Build \
 - $USER) ${COREOS_VERSION_TRACK} $FLAGS_board"
+  : ${COREOS_VERSION_AUSERVER:="http://$(hostname --fqdn):8080/update"}
+  : ${COREOS_VERSION_DEVSERVER:="http://$(hostname --fqdn):8080"}
 fi
+
+# TODO(marineam): come up with a way to support continous integration builds,
+# this would provide all the bells and whistles for 'master' branch images.
+#elif [ "$USER" = "chrome-bot" ]; then
+#  # Continuous builder
+#  COREOS_VERSION_TRACK="buildbot-build"
+#  COREOS_VERSION_DESCRIPTION="${COREOS_VERSION_STRING} (Continuous Build \
+#- Builder: ${BUILDBOT_BUILD:-"N/A"}) $FLAGS_board"
+
 
 # Set coreos-specific version numbers:
 # COREOS_RELEASE_BOARD is the target board identifier.
-# COREOS_RELEASE_DESCRIPTION is the version displayed by Chrome; see
-#   chrome/browser/chromeos/chromeos_version_loader.cc.
+# COREOS_RELEASE_DESCRIPTION is the extended human readable form.
 # COREOS_RELEASE_NAME is a human readable name for the build.
 # COREOS_RELEASE_TRACK and COREOS_RELEASE_VERSION are used by the software
 #   update service.
-sudo_append "${ROOT_FS_DIR}/etc/lsb-release" <<EOF
+# DISTRIB_* are the standard names for the same values.
+sudo_clobber "${ROOT_FS_DIR}/etc/lsb-release" <<EOF
+DISTRIB_ID=$COREOS_VERSION_NAME
+DISTRIB_RELEASE=$COREOS_VERSION_STRING
+DISTRIB_CODENAME="Black Squirrel's Revenge"
+DISTRIB_DESCRIPTION="$COREOS_VERSION_NAME $COREOS_VERSION_DESCRIPTION"
 COREOS_RELEASE_BOARD=$FLAGS_board
 COREOS_RELEASE_DESCRIPTION=$COREOS_VERSION_DESCRIPTION
 COREOS_RELEASE_NAME=$COREOS_VERSION_NAME
@@ -66,4 +75,25 @@ COREOS_RELEASE_TRACK=$COREOS_VERSION_TRACK
 COREOS_RELEASE_VERSION=$COREOS_VERSION_STRING
 COREOS_AUSERVER=$COREOS_VERSION_AUSERVER
 COREOS_DEVSERVER=$COREOS_VERSION_DEVSERVER
+EOF
+
+# For things like python which read gentoo-release
+sudo_clobber "${ROOT_FS_DIR}/etc/gentoo-release" <<EOF
+$COREOS_VERSION_NAME release $COREOS_VERSION_STRING
+EOF
+
+# Aaaannd for the new systemd world order
+# os-release provides a seperate build-id field, so split it from version
+OS_ID=$(tr '[:upper:]' '[:lower:]' <<<"$COREOS_VERSION_NAME")
+OS_VERION_ID="${COREOS_VERSION_STRING#*+}"
+OS_BUILD_ID="${COREOS_VERSION_STRING%%+*}"
+sudo_clobber "${ROOT_FS_DIR}/etc/os-release" <<EOF
+NAME=$COREOS_VERSION_NAME
+ID=$OS_ID
+VERSION=$COREOS_VERSION_STRING
+VERSION_ID=$OS_VERION_ID
+BUILD_ID=$OS_BUILD_ID
+PRETTY_NAME="$COREOS_VERSION_NAME $COREOS_VERSION_DESCRIPTION"
+ANSI_COLOR="1;32"
+HOME_URL="http://www.coreos.com/"
 EOF


### PR DESCRIPTION
Add --production_track argument to set_lsb_release and
cros_make_image_bootable to support using the production update service
on developer builds of the 'prod' image. This replaces the previous hack
of setting COREOS_OFFICIAL=1 in the middle of the build.

Since lsb-release doesn't exist prior to the first call to
set_lsb_release switch to sudo_clobber instead of append. That way if it
is called a second time later the contents aren't duplicated.

Write the info to gentoo-release and os-release as well so everything
gets the same information.
