### PR TITLE
fix(build_library): Re-enable zeroing free-space but in a sane way.

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -88,6 +88,10 @@ EOF
     sudo chmod a+rx "${path}"
   fi
 
+  # Zero all fs free space, not fatal since it won't work on linux < 3.2
+  sudo fstrim "${root_fs_dir}" || true
+  sudo fstrim "${stateful_fs_dir}" || true
+
   info "Developer image built and stored at ${image_name}"
 
   cleanup_mounts


### PR DESCRIPTION
As of Linux 3.2 loopback supports discard by punching holes in the
underlying file. This doesn't actually seem to impact things right now
since we are writing to fresh filesystems but might as well do this to
prevent wasted space from sneaking in later on.
