### PR TITLE
fix(test_ami): Bump socket startup timeout to 90 seconds.

### DIFF
--- a/oem/ami/test_ami.sh
+++ b/oem/ami/test_ami.sh
@@ -103,7 +103,7 @@ declare -a ips=($($ec2_cmd | grep INSTANCE | cut -f4))
 # sleep until all the sockets we need come up
 for host in ${ips[@]}; do
     for port in 22 4001 7001; do
-        timeout 30 perl -MIO::Socket::INET -e "
+        timeout 90 perl -MIO::Socket::INET -e "
             until(new IO::Socket::INET('$host:$port')){sleep 1}"
     done
 done


### PR DESCRIPTION
I've observed networking between ec2 instances not start working for
somewhere between 40-50 seconds earlier today which caused the test to
fail despite the fact that everything came up properly eventually.
Upping to 90 seconds should better cope with the surprises Amazon has to
offer.
