### PR TITLE
fix(make_chroot): Don't fail if user's full name is blank.

### DIFF
--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -147,7 +147,6 @@ init_users () {
     info "Adding user ${SUDO_USER}..."
     local full_name group_name
     full_name=$(getent passwd "${SUDO_USER}" | cut -d: -f5)
-    [[ -n "${full_name}" ]] || die "Looking up user $SUDO_USER failed."
     group_name=$(getent group "${SUDO_GID}" | cut -d: -f1)
     [[ -n "${group_name}" ]] || die "Looking up gid $SUDO_GID failed."
 


### PR DESCRIPTION
It is perfectly valid for the comment field in a passwd file to be
blank so don't treat that as an error. Sorry backjlack :-/
