### PR TITLE
feat(image_to_vm): Add 'vmware_insecure' image type.

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -14,6 +14,7 @@ VALID_IMG_TYPES=(
     vagrant_vmware_fusion
     virtualbox
     vmware
+    vmware_insecure
     xen
 )
 
@@ -75,6 +76,11 @@ IMG_vagrant_vmware_fusion_OEM_PACKAGE=oem-vagrant
 ## vmware
 IMG_vmware_DISK_FORMAT=vmdk
 IMG_vmware_CONF_FORMAT=vmx
+
+## vmware_insecure
+IMG_vmware_insecure_DISK_FORMAT=vmdk
+IMG_vmware_insecure_CONF_FORMAT=vmware_zip
+IMG_vmware_insecure_OEM_PACKAGE=oem-vagrant
 
 ## ami
 IMG_ami_HYBRID_MBR=1
@@ -331,14 +337,71 @@ ide0:0.present = "TRUE"
 ide0:0.fileName = "${dst_name}"
 ethernet0.present = "TRUE"
 usb.present = "TRUE"
-sound.present = "TRUE"
-sound.virtualDev = "es1371"
-displayName = "CoreOS"
+sound.present = "FALSE"
+displayName = "${VM_NAME}"
 guestOS = "otherlinux"
 ethernet0.addressType = "generated"
 floppy0.present = "FALSE"
 EOF
     VM_GENERATED_FILES+=( "${vmx_path}" )
+}
+
+_write_vmware_zip_conf() {
+    local src_name=$(basename "$VM_SRC_IMG")
+    local dst_name=$(basename "$VM_DST_IMG")
+    local dst_dir=$(dirname "$VM_DST_IMG")
+    local vmx_path="${dst_dir}/$(_src_to_dst_name "${src_name}" ".vmx")"
+    local vmx_file=$(basename "${vmx_path}")
+    local zip="${dst_dir}/$(_src_to_dst_name "${src_name}" ".zip")"
+
+    _write_vmx_conf "$1"
+
+    # Move the disk/vmx to tmp, they will be zipped.
+    mv "${VM_DST_IMG}" "${VM_TMP_DIR}/${dst_name}"
+    mv "${vmx_path}" "${VM_TMP_DIR}/${vmx_file}"
+    cat > "${VM_TMP_DIR}/insecure_ssh_key" <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzI
+w+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoP
+kcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2
+hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NO
+Td0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcW
+yLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQIBIwKCAQEA4iqWPJXtzZA68mKd
+ELs4jJsdyky+ewdZeNds5tjcnHU5zUYE25K+ffJED9qUWICcLZDc81TGWjHyAqD1
+Bw7XpgUwFgeUJwUlzQurAv+/ySnxiwuaGJfhFM1CaQHzfXphgVml+fZUvnJUTvzf
+TK2Lg6EdbUE9TarUlBf/xPfuEhMSlIE5keb/Zz3/LUlRg8yDqz5w+QWVJ4utnKnK
+iqwZN0mwpwU7YSyJhlT4YV1F3n4YjLswM5wJs2oqm0jssQu/BT0tyEXNDYBLEF4A
+sClaWuSJ2kjq7KhrrYXzagqhnSei9ODYFShJu8UWVec3Ihb5ZXlzO6vdNQ1J9Xsf
+4m+2ywKBgQD6qFxx/Rv9CNN96l/4rb14HKirC2o/orApiHmHDsURs5rUKDx0f9iP
+cXN7S1uePXuJRK/5hsubaOCx3Owd2u9gD6Oq0CsMkE4CUSiJcYrMANtx54cGH7Rk
+EjFZxK8xAv1ldELEyxrFqkbE4BKd8QOt414qjvTGyAK+OLD3M2QdCQKBgQDtx8pN
+CAxR7yhHbIWT1AH66+XWN8bXq7l3RO/ukeaci98JfkbkxURZhtxV/HHuvUhnPLdX
+3TwygPBYZFNo4pzVEhzWoTtnEtrFueKxyc3+LjZpuo+mBlQ6ORtfgkr9gBVphXZG
+YEzkCD3lVdl8L4cw9BVpKrJCs1c5taGjDgdInQKBgHm/fVvv96bJxc9x1tffXAcj
+3OVdUN0UgXNCSaf/3A/phbeBQe9xS+3mpc4r6qvx+iy69mNBeNZ0xOitIjpjBo2+
+dBEjSBwLk5q5tJqHmy/jKMJL4n9ROlx93XS+njxgibTvU6Fp9w+NOFD/HvxB3Tcz
+6+jJF85D5BNAG3DBMKBjAoGBAOAxZvgsKN+JuENXsST7F89Tck2iTcQIT8g5rwWC
+P9Vt74yboe2kDT531w8+egz7nAmRBKNM751U/95P9t88EDacDI/Z2OwnuFQHCPDF
+llYOUI+SpLJ6/vURRbHSnnn8a/XG+nzedGH5JGqEJNQsz+xT2axM0/W/CRknmGaJ
+kda/AoGANWrLCz708y7VYgAtW2Uf1DPOIYMdvo6fxIB5i9ZfISgcJ/bbCUkFrhoH
++vq/5CIWxCPp0f85R4qxxQ5ihxJ0YDQT9Jpx4TMss4PSavPaBH3RXow5Ohe+bYoQ
+NE5OgEXk2wVfZczCZpigBKbKZHNYcelXtTt/nP3rsCuGcM4h53s=
+-----END RSA PRIVATE KEY-----
+EOF
+    chmod 600 "${VM_TMP_DIR}/insecure_ssh_key"
+
+    zip --junk-paths "${zip}" \
+        "${VM_TMP_DIR}/${dst_name}" \
+        "${VM_TMP_DIR}/${vmx_file}" \
+        "${VM_TMP_DIR}/insecure_ssh_key"
+
+    cat > "${VM_README}" <<EOF
+Use insecure_ssh_key in the zip for login access.
+TODO: more instructions!
+EOF
+
+    # Replace list, not append, since we packaged up the disk image.
+    VM_GENERATED_FILES=( "${zip}" "${VM_README}" )
 }
 
 # Generate a new-style (xl) Xen config file for both pvgrub and pygrub


### PR DESCRIPTION
This bundles the vagrant ssh key, vmdk, and vmx into a zip file for easy
downloading and login access via ssh.
