### PR TITLE
fix(image_to_vm): Add missing call to check_gsutil_opts.

### DIFF
--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -60,6 +60,8 @@ eval set -- "${FLAGS_ARGV}"
 # Die on any errors.
 switch_to_strict_mode
 
+check_gsutil_opts
+
 if ! set_vm_type "${FLAGS_format}"; then
     die_notrace "Invalid format: ${FLAGS_format}"
 fi


### PR DESCRIPTION
The --upload_path argument was not being properly handled because this
was missing, creating lots of 54.0.0+2013-08-28-1810 style directories
instead of master. Oops.
