### PR TITLE
feat(update_bootloaders.sh) add UEFI boot support

### DIFF
--- a/update_bootloaders.sh
+++ b/update_bootloaders.sh
@@ -114,6 +114,11 @@ if [[ "${FLAGS_arch}" = "x86" || "${FLAGS_arch}" = "amd64" ]]; then
   sudo cp -f "${FLAGS_vmlinuz}" "${ESP_FS_DIR}"/syslinux/vmlinuz.A
   sudo cp -f "${FLAGS_vmlinuz}" "${ESP_FS_DIR}"/syslinux/vmlinuz.B
 
+  # create the EFI directory tree as a fall-back for UEFI builds and put a copy
+  # of the kernel in there.
+  sudo mkdir -p "${ESP_FS_DIR}"/EFI/boot
+  sudo cp -f "${FLAGS_vmlinuz}" "${ESP_FS_DIR}"/EFI/boot/bootx64.efi
+
   # Extract kernel flags
   kernel_cfg="cros_debug"
   old_root="%U+1"


### PR DESCRIPTION
This creates the EFI/BOOT/ directory in the boot partition and copies a
version of the kernel into there so that UEFI bioses can boot directly
into the kernel, no bootloader needed.
