### PR TITLE
fix(build_library): fix the pxe image instructions

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -440,7 +440,7 @@ _write_pxe_conf() {
 If you have qemu installed (or in the SDK), you can start the image with:
   cd path/to/image
 
-  qemu-kvm -kernel ${vmlinuz_name} -initrd ${dst_name} -append 'diskless sshkey="PUT AN SSH KEY HERE"'
+  qemu-kvm -m 1024 -kernel ${vmlinuz_name} -initrd ${dst_name} -append 'state=tmpfs: root=squashfs: sshkey="PUT AN SSH KEY HERE"'
 
 EOF
 


### PR DESCRIPTION
the args to the kernel have changed to state= and root=squashfs: also make the
boot be 1024Mb of RAM otherwise qemu falls over with initrds.
