### PR TITLE
fix(build_library): set tz to UTC in vmx template

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -478,6 +478,7 @@ scsi0:0.present = "TRUE"
 sound.present = "FALSE"
 usb.generic.autoconnect = "FALSE"
 usb.present = "TRUE"
+rtc.diffFromUTC = 0
 EOF
     VM_GENERATED_FILES+=( "${vmx_path}" )
 }


### PR DESCRIPTION
VMware is using the local time zone by default for the clock.
This PR changes the vmx template in vm_image_util.sh to set it to UTC
instead.
