### PR TITLE
fix(qemu_template.sh): force use of bash, since we use bashisms such as ...

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="`dirname "$0"`"
 VM_NAME=


### PR DESCRIPTION
...==

Fixes a bug a user was seeing: 

./coreos_production_qemu.sh: 42: [: -nographic: unexpected operator

This is because '==' is a bashism. 
