### PR TITLE
add(129.0.0_python_exec_transition.sh): gracefully upgrade python-exec

### DIFF
--- a/sdk_lib/updates/129.0.0_python_exec_transition.sh
+++ b/sdk_lib/updates/129.0.0_python_exec_transition.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Copyright (c) 2013 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Upgrade python-exec, will transition to dev-lang/python-exec
+sudo emerge -qu dev-python/python-exec
+
+# Re-install portage and gentoolkit which tended to have issues
+sudo emerge -q sys-apps/portage app-portage/gentoolkit


### PR DESCRIPTION
We've had trouble with eclean and equery vanishing in our SDKs from time
to time. Although I don't know the root cause it seemed to be some
confusion in the ebuild environment, perhaps a mis-match between the
eclasses, profiles, and ebuilds. Updating all of those seemed to resolve
the issue and to make sure other environments are ok force a re-install
of portage and gentoolkit to clean things up.
