### PR TITLE
fix(build_image): Properly clear the EXIT trap

### DIFF
--- a/build_library/base_image_util.sh
+++ b/build_library/base_image_util.sh
@@ -218,4 +218,6 @@ create_base_image() {
 
   ${SCRIPTS_DIR}/bin/cros_make_image_bootable "${BUILD_DIR}" \
     ${image_name} --adjust_part="${FLAGS_adjust_part}"
+
+  trap - EXIT
 }

--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -42,10 +42,11 @@ install_dev_packages() {
   info "Developer image built and stored at ${image_name}"
 
   cleanup_mounts
-  trap - EXIT
 
   if should_build_image ${image_name}; then
     ${SCRIPTS_DIR}/bin/cros_make_image_bootable "${BUILD_DIR}" \
       ${image_name} --force_developer_mode --noenable_rootfs_verification
   fi
+
+  trap - EXIT
 }


### PR DESCRIPTION
Now build_image will no longer claim that the build failed, prompting
you to delete the output directory, after a good build.

Resolves issue https://github.com/coreos/scripts/issues/142
