### PR TITLE
usr(build-artifacts): remove some things that portage automatically crea...

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -41,7 +41,7 @@ setup_prod_image() {
   # clear them out explicitly, so this fails if something else gets dropped
   # into xinetd.d
   sudo rm ${root_fs_dir}/etc/xinetd.d/rsyncd
-  sudo rm -r ${root_fs_dir}/etc/xinetd.d
+  sudo rmdir ${root_fs_dir}/etc/xinetd.d
 
   cleanup_mounts "${root_fs_dir}"
   trap - EXIT


### PR DESCRIPTION
These are a few random files that need to be deleted. /etc/gentoo-release is the scariest because some OS detection suites (like vagrant) use this. 
