### PR TITLE
fix(test_image_content): Remove check for localtime symlink

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -77,20 +77,6 @@ test_image_content() {
     fi
   done
 
-  # Check that /etc/localtime is a symbolic link pointing at
-  # /var/lib/timezone/localtime.
-  local localtime="$root/etc/localtime"
-  if [ ! -L "$localtime" ]; then
-    error "test_image_content: /etc/localtime is not a symbolic link"
-    returncode=1
-  else
-    local dest=$(readlink "$localtime")
-    if [ "$dest" != "/var/lib/timezone/localtime" ]; then
-      error "test_image_content: /etc/localtime points at $dest"
-      returncode=1
-    fi
-  fi
-
   # Check that the symlink-usr flag agrees with the filesystem state.
   # Things are likely to break if they don't match.
   if [[ $(ROOT="${root}" $portageq envvar USE) == *symlink-usr* ]]; then


### PR DESCRIPTION
We no longer provide this symlink, it was always broken anyway.
