### PR TITLE
fix(bootengine): Disable SMP in bootengine kernels.

### DIFF
--- a/build_library/create_legacy_bootloader_templates.sh
+++ b/build_library/create_legacy_bootloader_templates.sh
@@ -113,7 +113,7 @@ EOF
 label boot_kernel
   menu label boot_kernel
   kernel vmlinuz-boot_kernel
-  append ${syslinux_args} ${gptprio_args}
+  append ${syslinux_args} ${gptprio_args} maxcpus=1
 EOF
   info "Emitted ${SYSLINUX_DIR}/boot_kernel.cfg"
 


### PR DESCRIPTION
Mixing SMP + kexec + Virtual Machines has been trouble. I see
intermittent failures with QEMU/KVM 1.6 and breaks boot entirely on Xen
HVM. Not sure if this is enough to fix the Xen case though, will test
that soon...
