### PR TITLE
qemu_template: use /bin/bash instead of /bin/sh.

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -40,7 +40,7 @@ do
 done
 
 shift $((script_args - 1))
-[ "$1" == "--" ] && shift
+[ "$1" = "--" ] && shift
 
 
 METADATA=$(mktemp -t -d coreos-meta-data.XXXXXXXXXX)


### PR DESCRIPTION
/bin/sh doesn't always point to bash.
