### PR TITLE
fix(vm_image_util): assert qemu wrapper is sh friendly

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -329,6 +329,7 @@ _write_qemu_conf() {
         -e "s%^VM_IMAGE=.*%VM_IMAGE='${dst_name}'%" \
         -e "s%^VM_MEMORY=.*%VM_MEMORY='${vm_mem}'%" \
         "${BUILD_LIBRARY_DIR}/qemu_template.sh" > "${script}"
+    checkbashisms --posix "${script}" || die
     chmod +x "${script}"
 
     cat >"${VM_README}" <<EOF


### PR DESCRIPTION
This test was noted by @oremj in https://github.com/coreos/scripts/pull/166

Depends on https://github.com/coreos/coreos-overlay/pull/345
