### PR TITLE
fix(update_chroot): Install/update nss-usrfiles early

### DIFF
--- a/update_chroot
+++ b/update_chroot
@@ -118,6 +118,7 @@ sudo -E ${EMERGE_CMD} ${EMERGE_FLAGS} \
     sys-apps/portage \
     sys-devel/crossdev \
     sys-devel/sysroot-wrappers \
+    sys-libs/nss-usrfiles \
     "${TOOLCHAIN_PKGS[@]}"
 
 if [[ "${FLAGS_skip_toolchain_update}" -eq "${FLAGS_FALSE}" && \


### PR DESCRIPTION
Soon nss-usrfiles will be required to resolve users and groups properly.
To avoid potentially breaking during the transition we need to make sure
the package is installed early during the chroot upgrade process.
