### PR TITLE
fix(prod_image_util): restore /etc/gentoo-release

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -35,7 +35,6 @@ setup_prod_image() {
 
   # clean-ups of things we do not need
   sudo rm ${root_fs_dir}/etc/csh.env
-  sudo rm ${root_fs_dir}/etc/gentoo-release
   sudo rm -rf ${root_fs_dir}/var/db/pkg
   sudo rm ${root_fs_dir}/var/db/Makefile
   sudo rm ${root_fs_dir}/etc/locale.gen


### PR DESCRIPTION
Vagrant reads this file to determine that we are CoreOS... so lets not
break that just yet. A PR to switch to os-release has been posted:
https://github.com/mitchellh/vagrant/pull/2985

Some day gentoo-release will be dropped but that day is not today.
