### PR TITLE
fix(release_util): Fix DIGESTS regression from feb59db9f

### DIFF
--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -114,7 +114,7 @@ upload_image() {
         shift 2
     else
         [[ $# -eq 1 ]] || die "-d is required for multi-file uploads"
-        digests="${1}.DIGESTS"
+        # digests is assigned after image is possibly compressed/renamed
     fi
 
     local uploads=()
@@ -133,6 +133,10 @@ upload_image() {
             uploads+=( "${filename}" )
         fi
     done
+
+    if [[ -z "${digests}" ]]; then
+        digests="${uploads[0]}.DIGESTS"
+    fi
 
     # For consistency generate a .DIGESTS file similar to the one catalyst
     # produces for the SDK tarballs and up upload it too.

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -645,20 +645,26 @@ vm_upload() {
     # consistent and relying on ordering was breakable.
     # Now the common prefix, output by $(_dst_name) is used above.
     # Some download/install scripts may still refer to the old name.
-    local uploaded legacy_digests
+    local uploaded legacy_uploaded
     for uploaded in "${VM_GENERATED_FILES[@]}"; do
         if [[ "${uploaded}" == "${VM_DST_IMG}" ]]; then
-            legacy_digests="$(_dst_dir)/$(basename ${VM_DST_IMG}).DIGESTS"
+            legacy_uploaded="$(_dst_dir)/$(basename ${VM_DST_IMG})"
             break
         fi
     done
 
     # Since depending on the ordering of $VM_GENERATED_FILES is brittle only
     # use it if $VM_DST_IMG isn't included in the uploaded files.
-    if [[ -z "${legacy_digests}" ]]; then
-        legacy_digests="${VM_GENERATED_FILES[0]}.DIGESTS"
+    if [[ -z "${legacy_uploaded}" ]]; then
+        legacy_uploaded="${VM_GENERATED_FILES[0]}"
     fi
 
+    # If upload_images compressed $legacy_uploaded be sure to add .bz2
+    if [[ "${legacy_uploaded}" =~ \.(img|bin|vdi|vmdk)$ ]]; then
+        legacy_uploaded+="${IMAGE_ZIPEXT}"
+    fi
+
+    local legacy_digests="${legacy_uploaded}.DIGESTS"
     [[ "${legacy_digests}" != "${digests}" ]] || return 0
 
     local legacy_uploads=( "${legacy_digests}" )


### PR DESCRIPTION
While attempting to fix the easy to mix up DIGESTS names in feb59db9f I
stumbled across yet another way that the DIGESTS names were a bit
unpredictable: previously a .bz2 got stuck into the file name when
upload_images automatically compressed some file types. The new code
missed this and never added the .bz2. Correct this now, both for
image_to_vm which has a pile of glue to keep the legacy names in place
for now and build_image which I never intended to change.
