### PR TITLE
fix(build_image): Switch STATE/ROOT partitions to coreos-resize type.

### DIFF
--- a/build_library/legacy_disk_layout.json
+++ b/build_library/legacy_disk_layout.json
@@ -61,7 +61,7 @@
       },
       "9":{
         "label":"STATE",
-        "type":"data",
+        "type":"coreos-resize",
         "blocks":"1048576",
         "fs_type":"ext4",
         "mount":"/media/state",
@@ -90,7 +90,6 @@
     "vm":{
       "9":{
         "label":"STATE",
-        "type":"data",
         "blocks":"6291456"
       }
     },
@@ -112,7 +111,6 @@
     "vagrant":{
       "9":{
         "label":"STATE",
-        "type":"data",
         "blocks":"33587200"
       }
     },


### PR DESCRIPTION
This is used by the new resize implementation to identify which
partition to resize during boot.
