### PR TITLE
fix(catalyst): Don't disable ebuild-locks

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -74,8 +74,6 @@ cat <<EOF
 export TERM='${TERM}'
 export MAKEOPTS='--jobs=${NUM_JOBS} --load-average=${load}'
 export EMERGE_DEFAULT_OPTS="\$MAKEOPTS"
-# Catalyst overrides FEATURES so set it's own variable instead.
-export clst_myfeatures='-ebuild-locks'
 EOF
 }
 


### PR DESCRIPTION
This doesn't make things go faster and I am suspicious that it makes
things worse. For example /etc/xml/catalog winds up empty from time to
time and I wonder if this locking is related to that.
