### PR TITLE
fix(vm_image_util): Skip kexec when booting on Xen HVM

### DIFF
--- a/build_library/configure_bootloaders.sh
+++ b/build_library/configure_bootloaders.sh
@@ -95,7 +95,9 @@ configure_syslinux() {
 SERIAL 0 115200
 PROMPT 0
 TIMEOUT 0
-DEFAULT boot_kernel
+
+# controls which kernel is the default
+include /syslinux/default.cfg
 
 include /syslinux/boot_kernel.cfg
 
@@ -106,6 +108,21 @@ include /syslinux/root.A.cfg
 include /syslinux/root.B.cfg
 EOF
   info "Emitted ${SYSLINUX_DIR}/syslinux.cfg"
+
+  sudo_clobber "${SYSLINUX_DIR}/default.cfg" <<EOF
+DEFAULT boot_kernel
+EOF
+  info "Emitted ${SYSLINUX_DIR}/default.cfg"
+
+  sudo_clobber "${SYSLINUX_DIR}/default.cfg.A" <<EOF
+DEFAULT coreos.A
+EOF
+  info "Emitted ${SYSLINUX_DIR}/default.cfg.A"
+
+  sudo_clobber "${SYSLINUX_DIR}/default.cfg.B" <<EOF
+DEFAULT coreos.B
+EOF
+  info "Emitted ${SYSLINUX_DIR}/default.cfg.B"
 
   # Different files are used so that the updater can only touch the file it
   # needs to for a given change.  This will minimize any potential accidental

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -43,6 +43,9 @@ IMG_DEFAULT_HYBRID_MBR=0
 # If set to 0 then a partition skeleton won't be laid out on VM_TMP_IMG
 IMG_DEFAULT_PARTITIONED_IMG=1
 
+# If set to 0 boot_kernel is skipped
+IMG_DEFAULT_BOOT_KERNEL=1
+
 # If set install the given package name to the OEM partition
 IMG_DEFAULT_OEM_PACKAGE=
 
@@ -67,6 +70,7 @@ IMG_qemu_CONF_FORMAT=qemu
 ## xen
 # Hybrid is required by pvgrub (pygrub supports GPT but we support both)
 IMG_xen_HYBRID_MBR=1
+IMG_xen_BOOT_KERNEL=0
 IMG_xen_CONF_FORMAT=xl
 
 ## virtualbox
@@ -99,6 +103,7 @@ IMG_vmware_insecure_OEM_PACKAGE=oem-vagrant
 
 ## ami
 IMG_ami_HYBRID_MBR=1
+IMG_ami_BOOT_KERNEL=0
 IMG_ami_OEM_PACKAGE=oem-ami
 
 ## openstack, supports ec2's metadata format so use oem-ami
@@ -117,7 +122,7 @@ IMG_gce_CONF_FORMAT=gce
 IMG_gce_OEM_PACKAGE=oem-gce
 
 ## rackspace
-# TODO: package doesn't exist yet
+IMG_rackspace_BOOT_KERNEL=0
 IMG_rackspace_OEM_PACKAGE=oem-rackspace
 
 ###########################################################
@@ -217,6 +222,11 @@ setup_disk_image() {
     info "Mounting image to $(relpath "${VM_TMP_ROOT}")"
     "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout="${disk_layout}" \
         mount "${VM_TMP_IMG}" "${VM_TMP_ROOT}"
+
+    local SYSLINUX_DIR="${VM_TMP_ROOT}/boot/efi/syslinux"
+    if [[ $(_get_vm_opt BOOT_KERNEL) -eq 0 ]]; then
+        sudo mv "${SYSLINUX_DIR}/default.cfg.A" "${SYSLINUX_DIR}/default.cfg"
+    fi
 }
 
 # If the current type defines a oem package install it to the given fs image.


### PR DESCRIPTION
This is buggy, instead we will need to handle Xen HVM similar to PV
except this requires SYSLINUX config tweaking instead of grub's menu.lst
