### PR TITLE
fix(build_image): The kernel is now in /usr/boot

### DIFF
--- a/build_library/base_image_util.sh
+++ b/build_library/base_image_util.sh
@@ -55,10 +55,15 @@ create_base_image() {
   --root="${root_fs_dir}" \
   --board="${BOARD}"
 
+  local boot_dir="/boot"
+  if [[ "${disk_layout}" == *-usr ]]; then
+    boot_dir="/usr/boot"
+  fi
+
   ${BUILD_LIBRARY_DIR}/configure_bootloaders.sh \
     --arch=${ARCH} \
     --disk_layout="${disk_layout}" \
-    --boot_dir="${root_fs_dir}"/boot \
+    --boot_dir="${root_fs_dir}${boot_dir}" \
     --esp_dir="${root_fs_dir}"/boot/efi \
     --boot_args="${FLAGS_boot_args}"
 

--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -43,7 +43,7 @@ test_image_content() {
   local portageq="portageq-$BOARD"
 
   local binaries=(
-    "$root/boot/vmlinuz"
+    "$root/usr/boot/vmlinuz"
     "$root/bin/sed"
   )
 


### PR DESCRIPTION
Should be merged along side https://github.com/coreos/coreos-overlay/pull/410
