### PR TITLE
feat(vm_image_util): Add qemu_no_kexec image type

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -10,6 +10,7 @@ VALID_IMG_TYPES=(
     pxe
     openstack
     qemu
+    qemu_no_kexec
     rackspace
     vagrant
     vagrant_vmware_fusion
@@ -63,6 +64,11 @@ IMG_DEFAULT_MEM=1024
 IMG_qemu_DISK_FORMAT=qcow2
 IMG_qemu_DISK_LAYOUT=vm
 IMG_qemu_CONF_FORMAT=qemu
+
+IMG_qemu_no_kexec_BOOT_KERNEL=0
+IMG_qemu_no_kexec_DISK_FORMAT=qcow2
+IMG_qemu_no_kexec_DISK_LAYOUT=vm
+IMG_qemu_no_kexec_CONF_FORMAT=qemu
 
 ## xen
 IMG_xen_BOOT_KERNEL=0


### PR DESCRIPTION
This makes it easy to test booting without kexec on qemu/kvm similar to
how images are booted on Xen.
