### PR TITLE
cleanup(set_lsb_release): Rework release config setup

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -60,8 +60,7 @@ if [[ "$STAGES" =~ stage4 ]]; then
     rm -rf "${TEMPDIR}/stage4_overlay"
     mkdir -p "${TEMPDIR}/stage4_overlay"
     "${BUILD_LIBRARY_DIR}/set_lsb_release" \
-        --root "${TEMPDIR}/stage4_overlay" \
-        --production_track sdk --board "${ARCH}-host"
+        --root "${TEMPDIR}/stage4_overlay"
 fi
 
 catalyst_build

--- a/build_container
+++ b/build_container
@@ -34,8 +34,7 @@ if [[ "$STAGES" =~ stage4 ]]; then
     rm -rf "${TEMPDIR}/stage4_overlay"
     mkdir -p "${TEMPDIR}/stage4_overlay"
     "${BUILD_LIBRARY_DIR}/set_lsb_release" \
-        --root "${TEMPDIR}/stage4_overlay" \
-        --production_track sdk --board "${ARCH}-host"
+        --root "${TEMPDIR}/stage4_overlay"
 fi
 
 catalyst_build

--- a/build_image
+++ b/build_image
@@ -23,6 +23,8 @@ DEFINE_string output_root "${DEFAULT_BUILD_ROOT}/images" \
   "Directory in which to place image result directories (named by version)"
 DEFINE_string disk_layout "base" \
   "The disk layout type to use for this image."
+DEFINE_string prod_group "" \
+  "The update group for production images."
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
@@ -122,6 +124,14 @@ mkdir -p "${BUILD_DIR}"
 DISK_LAYOUT_SUFFIX=$(portageq-$BOARD envvar COREOS_DISK_LAYOUT_SUFFIX)
 DISK_LAYOUT="${FLAGS_disk_layout:-base}${DISK_LAYOUT_SUFFIX}"
 
+if [[ -z "${FLAGS_prod_group}" ]]; then
+  if [[ "$BOARD" == "amd64-generic" ]]; then
+    FLAGS_prod_group="dev-channel"
+  else
+    FLAGS_prod_group="alpha"
+  fi
+fi
+
 # Create the base image.
 create_base_image ${PRISTINE_IMAGE_NAME} ${DISK_LAYOUT}
 if should_build_image ${PRISTINE_IMAGE_NAME}; then
@@ -149,7 +159,7 @@ if should_build_image ${COREOS_PRODUCTION_IMAGE_NAME}; then
   copy_image ${CHROMEOS_BASE_IMAGE_NAME} ${COREOS_PRODUCTION_IMAGE_NAME}
 
   setup_prod_image ${COREOS_PRODUCTION_IMAGE_NAME} ${DISK_LAYOUT} \
-    "dev-channel" \
+    "${FLAGS_prod_group}" \
     ${SRC_ROOT}/third_party/coreos-overlay/coreos-base/coreos-au-key/files/update-payload-key.pub.pem
 
   upload_image "${BUILD_DIR}/${COREOS_PRODUCTION_IMAGE_NAME}"

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -6,7 +6,7 @@
 setup_prod_image() {
   local image_name="$1"
   local disk_layout="$2"
-  local update_track="$3"
+  local update_group="$3"
   local au_key="$4"
 
   info "Configuring production image ${image_name}"
@@ -22,7 +22,7 @@ setup_prod_image() {
 
   # Replace /etc/lsb-release on the image.
   "${BUILD_LIBRARY_DIR}/set_lsb_release" \
-    --production_track="${update_track}" \
+    --group="${update_group}" \
     --root="${root_fs_dir}" \
     --board="${BOARD}"
 

--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -18,8 +18,7 @@ fi
 # Flags
 DEFINE_string board "" "The board to build an image for."
 DEFINE_string root "" "The root file system to write /etc/lsb-release to."
-DEFINE_string production_track "${PRODUCTION_DEFAULT}" \
-    "Use production values and a given track for update service."
+DEFINE_string group "" "The default update group for update_engine."
 
 # Parse command line
 FLAGS "$@" || exit 1
@@ -32,71 +31,24 @@ ROOT_FS_DIR="$FLAGS_root"
 [ -d "$ROOT_FS_DIR" ] || die "Root FS does not exist? ($ROOT_FS_DIR)"
 
 COREOS_VERSION_NAME="CoreOS"
-if [[ -n "${FLAGS_production_track}" ]]; then
+COREOS_VERSION_AUSERVER=""
+if [[ -n "${FLAGS_group}" ]]; then
   if [[ "${FLAGS_board}" == "amd64-usr" ]]; then
-    FLAGS_production_track="alpha"
+    COREOS_VERSION_AUSERVER="http://public.roller.core-os.net/v1/update/"
+  elif [[ "${FLAGS_board}" == "amd64-generic" ]]; then
+    COREOS_VERSION_AUSERVER="https://api.core-os.net/v1/update/"
   fi
-  COREOS_VERSION_TRACK="${FLAGS_production_track}"
-  COREOS_VERSION_DESCRIPTION="${COREOS_VERSION_STRING} (Official Build) \
-${COREOS_VERSION_TRACK} $FLAGS_board test"
-  if [[ "${FLAGS_production_track}" != "sdk" ]]; then
-    if [[ "${FLAGS_board}" == "amd64-usr" ]]; then
-      COREOS_VERSION_AUSERVER="http://public.roller.core-os.net/v1/update/"
-    else
-      COREOS_VERSION_AUSERVER="https://api.core-os.net/v1/update/"
-    fi
-  else
-    COREOS_VERSION_AUSERVER=""
-  fi
-  COREOS_VERSION_DEVSERVER=""
-else
-  # Developer hand-builds
-  COREOS_VERSION_TRACK=${COREOS_VERSION_TRACK:-"developer-build"}
-  COREOS_VERSION_DESCRIPTION="${COREOS_VERSION_STRING} (Developer Build \
-- $USER) ${COREOS_VERSION_TRACK} $FLAGS_board"
-  : ${COREOS_VERSION_AUSERVER:="http://$(hostname --fqdn):8080/update"}
-  : ${COREOS_VERSION_DEVSERVER:="http://$(hostname --fqdn):8080"}
 fi
 
-
-# TODO(marineam): come up with a way to support continous integration builds,
-# this would provide all the bells and whistles for 'master' branch images.
-#elif [ "$USER" = "chrome-bot" ]; then
-#  # Continuous builder
-#  COREOS_VERSION_TRACK="buildbot-build"
-#  COREOS_VERSION_DESCRIPTION="${COREOS_VERSION_STRING} (Continuous Build \
-#- Builder: ${BUILDBOT_BUILD:-"N/A"}) $FLAGS_board"
-
-
-# Set coreos-specific version numbers:
-# COREOS_RELEASE_BOARD is the target board identifier.
-# COREOS_RELEASE_DESCRIPTION is the extended human readable form.
-# COREOS_RELEASE_NAME is a human readable name for the build.
-# COREOS_RELEASE_TRACK and COREOS_RELEASE_VERSION are used by the software
-#   update service.
-# DISTRIB_* are the standard names for the same values.
-sudo mkdir -p "${ROOT_FS_DIR}/usr/share/coreos"
+# DISTRIB_* are the standard lsb-release names
+sudo mkdir -p "${ROOT_FS_DIR}/usr/share/coreos" "${ROOT_FS_DIR}/etc"
 sudo_clobber "${ROOT_FS_DIR}/usr/share/coreos/lsb-release" <<EOF
 DISTRIB_ID=$COREOS_VERSION_NAME
 DISTRIB_RELEASE=$COREOS_VERSION_STRING
 DISTRIB_CODENAME="Bear Creek Manor"
-DISTRIB_DESCRIPTION="$COREOS_VERSION_NAME $COREOS_VERSION_DESCRIPTION"
-COREOS_RELEASE_BOARD=$FLAGS_board
-COREOS_RELEASE_DESCRIPTION="$COREOS_VERSION_DESCRIPTION"
-COREOS_RELEASE_NAME=$COREOS_VERSION_NAME
-COREOS_RELEASE_TRACK=$COREOS_VERSION_TRACK
-COREOS_RELEASE_VERSION=$COREOS_VERSION_STRING
-COREOS_AUSERVER=$COREOS_VERSION_AUSERVER
-COREOS_DEVSERVER=$COREOS_VERSION_DEVSERVER
+DISTRIB_DESCRIPTION="$COREOS_VERSION_NAME $COREOS_VERSION_STRING"
 EOF
-
-sudo mkdir -p "${ROOT_FS_DIR}/etc"
 sudo ln -sf "../usr/share/coreos/lsb-release" "${ROOT_FS_DIR}/etc/lsb-release"
-
-# For things like python which read gentoo-release
-sudo_clobber "${ROOT_FS_DIR}/etc/gentoo-release" <<EOF
-$COREOS_VERSION_NAME release $COREOS_VERSION_STRING
-EOF
 
 # Aaaannd for the new systemd world order
 # os-release provides a separate build-id field, so split it from version
@@ -107,21 +59,22 @@ ID=$OS_ID
 VERSION=$COREOS_VERSION_STRING
 VERSION_ID=$COREOS_VERSION_ID
 BUILD_ID=$COREOS_BUILD_ID
-PRETTY_NAME="$COREOS_VERSION_NAME $COREOS_VERSION_DESCRIPTION"
+PRETTY_NAME="$COREOS_VERSION_NAME $COREOS_VERSION_STRING"
 ANSI_COLOR="1;32"
 HOME_URL="http://www.coreos.com/"
 EOF
-# The first time through the image, we have an os-release from a package,
-# the second time through this script, we don't, so we need to test if it's
-# present before trying to remove it.
 sudo ln -sf "../usr/share/coreos/os-release" "${ROOT_FS_DIR}/etc/os-release"
 
 # Create the defaults for the coreos configuration files in the usr directory
 sudo_clobber "${ROOT_FS_DIR}/usr/share/coreos/release" <<EOF
 COREOS_RELEASE_VERSION=$COREOS_VERSION_STRING
+COREOS_RELEASE_BOARD=$FLAGS_board
 EOF
 
 sudo_clobber "${ROOT_FS_DIR}/usr/share/coreos/update.conf" <<EOF
 SERVER=$COREOS_VERSION_AUSERVER
-GROUP=$COREOS_VERSION_TRACK
+GROUP=$FLAGS_group
 EOF
+
+# For old versions of vagrant
+sudo_clobber "${ROOT_FS_DIR}/etc/gentoo-release" <<<"$COREOS_VERSION_NAME"

--- a/update_chroot
+++ b/update_chroot
@@ -60,8 +60,8 @@ switch_to_strict_mode
 create_host_setup
 
 # Run version hooks as pre-update
-if [[ -f /etc/lsb-release ]]; then
-  OLDVER=$(grep "^COREOS_RELEASE_VERSION=" /etc/lsb-release | cut -d = -f 2-)
+if [[ -f /etc/os-release ]]; then
+  OLDVER=$(grep "^VERSION=" /etc/os-release | cut -d = -f 2-)
 else
   OLDVER="0.0.0"
 fi
@@ -84,9 +84,7 @@ for update_script in ${SCRIPTS_DIR}/sdk_lib/updates/*.sh; do
   fi
 done
 
-"${BUILD_LIBRARY_DIR}/set_lsb_release" \
-    --root / --production_track sdk \
-    --board "$(portageq envvar ARCH)-host"
+"${BUILD_LIBRARY_DIR}/set_lsb_release" --root /
 
 EMERGE_FLAGS="-uNv --with-bdeps=y --select"
 if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then


### PR DESCRIPTION
- Remove custom COREOS_\* attributes from /etc/lsb-release
- Move dev image logic to dev_image_util
  For extra fun fix detection of local host URL for devserver.
- Remove weirdly verbose "DESCRIPTION" format.
- Add COREOS_RELEASE_BOARD back to /usr/share/coreos/release
  This is mostly just so update_engine and gmerge report the correct
  board name to devserver, informative-only on prod images.
- Remove version info from /etc/gentoo-release
- Switch from 'track' to 'group' terminology.
