### PR TITLE
fix(build_image): Switch to SYSLINUX for our EFI bootloader.

### DIFF
--- a/build_library/configure_bootloaders.sh
+++ b/build_library/configure_bootloaders.sh
@@ -162,11 +162,14 @@ copy_to_esp() {
   sudo cp -r "${GRUB_DIR}/." "${FLAGS_esp_dir}/boot/grub"
   sudo cp -r "${SYSLINUX_DIR}/." "${FLAGS_esp_dir}/syslinux"
 
+  # Install UEFI bootloader
+  sudo cp /usr/share/syslinux/efi64/ldlinux.e64 \
+    "${FLAGS_esp_dir}/EFI/boot/ldlinux.e64"
+  sudo cp /usr/share/syslinux/efi64/syslinux.efi \
+    "${FLAGS_esp_dir}/EFI/boot/bootx64.efi"
+
   # Stage all kernels with the only one we built.
-  # FIXME(marineam): without an EFI bootloader like gummiboot we currently
-  # don't have a way to set the correct mount options based on disk layout.
-  for kernel in syslinux/{vmlinuz-boot_kernel,vmlinuz.A,vmlinuz.B} \
-                EFI/boot/bootx64.efi
+  for kernel in syslinux/{vmlinuz-boot_kernel,vmlinuz.A,vmlinuz.B}
   do
     sudo cp "${FLAGS_boot_dir}/vmlinuz" "${FLAGS_esp_dir}/${kernel}"
   done


### PR DESCRIPTION
Now with SYSLINUX 6 we can use the same bootloader on EFI and BIOS
systems. This replaces our previous reliance on building default kernel
options into the kernel image itself.
