### PR TITLE
fix(toolchain_util): Correct default binhost ordering.

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -118,7 +118,7 @@ get_board_binhost() {
     shift
 
     if [[ $# -eq 0 ]]; then
-        set -- "${COREOS_VERSION_ID}" "${COREOS_SDK_VERSION}"
+        set -- "${COREOS_SDK_VERSION}" "${COREOS_VERSION_ID}"
     fi
 
     for ver in "$@"; do


### PR DESCRIPTION
Later hosts in the list override earlier hosts so the current version
must be listed after the older sdk version.
