### PR TITLE
fix(vm_image_util): Do not generate a machine UUID.

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -98,12 +98,14 @@ if [ -n "${VM_INITRD}" ]; then
     set -- -initrd "${SCRIPT_DIR}/${VM_INITRD}" "$@"
 fi
 
+if [ -n "${VM_UUID}" ]; then
+    set -- -uuid "$VM_UUID" "$@"
+fi
 
 # Default to KVM, fall back on full emulation
 # ${METADATA} will be mounted in CoreOS as /media/metadata
 qemu-system-x86_64 \
     -name "$VM_NAME" \
-    -uuid "$VM_UUID" \
     -m ${VM_MEMORY} \
     -machine accel=kvm:tcg \
     -net nic,vlan=0,model=virtio \

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -33,7 +33,6 @@ VM_TMP_ROOT=
 VM_DST_IMG=
 VM_README=
 VM_NAME=
-VM_UUID=
 
 # Contains a list of all generated files
 VM_GENERATED_FILES=()
@@ -161,7 +160,6 @@ set_vm_paths() {
     VM_TMP_IMG="${VM_TMP_DIR}/disk_image.bin"
     VM_TMP_ROOT="${VM_TMP_DIR}/rootfs"
     VM_NAME="$(_src_to_dst_name "${src_name}" "")-${COREOS_VERSION_STRING}"
-    VM_UUID=$(uuidgen)
     VM_README="${dst_dir}/$(_src_to_dst_name "${src_name}" ".README")"
 }
 
@@ -349,7 +347,6 @@ _write_qemu_common() {
     local vm_mem="$(_get_vm_opt MEM)"
 
     sed -e "s%^VM_NAME=.*%VM_NAME='${VM_NAME}'%" \
-        -e "s%^VM_UUID=.*%VM_UUID='${VM_UUID}'%" \
         -e "s%^VM_MEMORY=.*%VM_MEMORY='${vm_mem}'%" \
         "${BUILD_LIBRARY_DIR}/qemu_template.sh" > "${script}"
     checkbashisms --posix "${script}" || die
@@ -518,7 +515,6 @@ _write_xl_conf() {
 
 builder = "generic"
 name = "${VM_NAME}"
-uuid = "${VM_UUID}"
 
 memory = "${vm_mem}"
 vcpus = 2


### PR DESCRIPTION
If QEMU is given a uuid systemd will detect that and in turn use it for
the machine-id. This made the bug causing the machine-id to be always
re-generated on boot harder to notice since it didn't happen on QEMU.
