### PR TITLE
fix(vm_image_util): Default to larger vm (8GB) disk layout for GCE

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -118,6 +118,7 @@ IMG_pxe_PARTITIONED_IMG=0
 IMG_pxe_CONF_FORMAT=pxe
 
 ## gce, image tarball
+IMG_gce_DISK_LAYOUT=vm
 IMG_gce_CONF_FORMAT=gce
 IMG_gce_OEM_PACKAGE=oem-gce
 


### PR DESCRIPTION
GCE was using the base 3GB layout which isn't very useful for actual
machines.
