### PR TITLE
fix(build_library): use https://public.update.core-os.net now

### DIFF
--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -34,7 +34,7 @@ COREOS_VERSION_NAME="CoreOS"
 COREOS_VERSION_AUSERVER=""
 if [[ -n "${FLAGS_group}" ]]; then
   if [[ "${FLAGS_board}" == "amd64-usr" ]]; then
-    COREOS_VERSION_AUSERVER="http://public.roller.core-os.net/v1/update/"
+    COREOS_VERSION_AUSERVER="https://public.update.core-os.net/v1/update/"
   elif [[ "${FLAGS_board}" == "amd64-generic" ]]; then
     COREOS_VERSION_AUSERVER="https://api.core-os.net/v1/update/"
   fi


### PR DESCRIPTION
We added a new https certificate on the new update service and changed the
hostname to be consistent with all of the other endpoints. Update the new
images to use this.

The old URL http://public.roller.core-os.net will remain working until all of
the old client have been updated.
