### PR TITLE
fix(oem/ami): Disable parallel AMI copying

### DIFF
--- a/oem/ami/copy_ami.sh
+++ b/oem/ami/copy_ami.sh
@@ -135,10 +135,7 @@ for r in "${!AKI[@]}"
 do
     [ "${r}" == "${region}" ] && continue
     echo "Starting copy of $AMI from $region to $r"
-    do_copy "$r" &
-    sleep 15
+    do_copy "$r"
 done
-
-wait
 
 echo "Done"


### PR DESCRIPTION
The parallelism appears to be what was breaking the fussy ec2 command
line tools. Just do it serially instead.
