### PR TITLE
fix(disk_util): Switch back to gptmbr.bin for our MBR boot code.

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -15,8 +15,8 @@ import uuid
 # First sector we can use.
 GPT_RESERVED_SECTORS = 34
 
-# Default MBR boot code for hybrid MBRs
-DEFAULT_MBR_BOOT_CODE = '/usr/share/syslinux/mbr.bin'
+# Default MBR boot code for GPT
+DEFAULT_MBR_BOOT_CODE = '/usr/share/syslinux/gptmbr.bin'
 
 
 class ConfigNotFound(Exception):


### PR DESCRIPTION
Using the classic mbr.bin was only needed during the transition from
syslinux 3 to 6 because the behavior of gptmbr.bin changed after 3.
Now that the transition is done and cgpt supports the new scheme now it
is time we switched back. This avoids depending on using a hybrid MBR.
