### PR TITLE
fix(syslinux): Display boot: prompt for a half second.

### DIFF
--- a/build_library/configure_bootloaders.sh
+++ b/build_library/configure_bootloaders.sh
@@ -93,8 +93,11 @@ configure_syslinux() {
 
   sudo_clobber "${SYSLINUX_DIR}/syslinux.cfg" <<EOF
 SERIAL 0 115200
-PROMPT 0
-TIMEOUT 0
+PROMPT 1
+# display boot: prompt for a half second
+TIMEOUT 5
+# never sit at the prompt longer than a minute
+TOTALTIMEOUT 600
 
 # controls which kernel is the default
 include /syslinux/default.cfg


### PR DESCRIPTION
This should make it less difficult for people to add kernel options for
debugging. Without a prompt/timeout the user must be holding down space
or some other key while syslinux loads but it may not be possible for
the user to do so provide input quite that fast. Only a half second to
avoid needlessly increasing boot times in the common case.
