### PR TITLE
maint(build_library): Remove special case code for -usr disk layouts

### DIFF
--- a/build_image
+++ b/build_image
@@ -131,8 +131,7 @@ fi
 # Create the output directory and temporary mount points.
 mkdir -p "${BUILD_DIR}"
 
-DISK_LAYOUT_SUFFIX=$(portageq-$BOARD envvar COREOS_DISK_LAYOUT_SUFFIX)
-DISK_LAYOUT="${FLAGS_disk_layout:-base}${DISK_LAYOUT_SUFFIX}"
+DISK_LAYOUT="${FLAGS_disk_layout:-base}"
 
 # Create the base image.
 create_base_image "${PRISTINE_IMAGE_NAME}" "${DISK_LAYOUT}" "${FLAGS_group}"

--- a/build_library/configure_bootloaders.sh
+++ b/build_library/configure_bootloaders.sh
@@ -40,17 +40,11 @@ get_uuid() {
       readuuid "$1"
 }
 
-# Filesystem args differ between the old and new usr layouts.
-if [[ "${FLAGS_disk_layout}" == *-usr ]]; then
-  root_args="root=LABEL=ROOT rootflags=subvol=root"
-  gptprio_args="${root_args} usr=gptprio:"
-  slot_a_args="${root_args} usr=PARTUUID=$(get_uuid USR-A)"
-  slot_b_args="${root_args} usr=PARTUUID=$(get_uuid USR-B)"
-else
-  gptprio_args="root=gptprio:"
-  slot_a_args="root=PARTUUID=$(get_uuid ROOT-A)"
-  slot_b_args="root=PARTUUID=$(get_uuid ROOT-B)"
-fi
+# Filesystem command line args.
+root_args="root=LABEL=ROOT rootflags=subvol=root"
+gptprio_args="${root_args} usr=gptprio:"
+slot_a_args="${root_args} usr=PARTUUID=$(get_uuid USR-A)"
+slot_b_args="${root_args} usr=PARTUUID=$(get_uuid USR-B)"
 
 GRUB_DIR="${FLAGS_boot_dir}/grub"
 SYSLINUX_DIR="${FLAGS_boot_dir}/syslinux"

--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -100,19 +100,11 @@ EOF
   # The remount services are provided by coreos-base/coreos-init
   local fs_wants="${root_fs_dir}/usr/lib/systemd/system/local-fs.target.wants"
   sudo mkdir -p "${fs_wants}"
-  if [[ "${disk_layout}" == *-usr ]]; then
-    sudo ln -s ../remount-usr.service "${fs_wants}"
-  else
-    sudo ln -s ../remount-root.service "${fs_wants}"
-  fi
+  sudo ln -s ../remount-usr.service "${fs_wants}"
 
   # Zero all fs free space, not fatal since it won't work on linux < 3.2
   sudo fstrim "${root_fs_dir}" || true
-  if [[ "${disk_layout}" == *-usr ]]; then
-    sudo fstrim "${root_fs_dir}/usr" || true
-  else
-    sudo fstrim "${root_fs_dir}/media/state" || true
-  fi
+  sudo fstrim "${root_fs_dir}/usr" || true
 
   info "Developer image built and stored at ${image_name}"
 

--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -21,16 +21,16 @@
         "blocks":"131072"
       },
       "3":{
-        "label":"ROOT-A",
+        "label":"USR-A",
         "uuid":"7130c94a-213a-4e5a-8e26-6cce9662f132",
         "type":"coreos-rootfs",
         "blocks":"2097152",
         "fs_blocks":"262144",
         "fs_type":"ext2",
-        "mount":"/"
+        "mount":"/usr"
       },
       "4":{
-        "label":"ROOT-B",
+        "label":"USR-B",
         "uuid":"e03dd35c-7c2d-4a47-b3fe-27f15780a57c",
         "type":"coreos-rootfs",
         "blocks":"2097152",
@@ -60,78 +60,23 @@
         "blocks":"0"
       },
       "9":{
-        "label":"STATE",
+        "label":"ROOT",
         "type":"coreos-resize",
         "blocks":"1048576",
-        "fs_type":"ext4",
-        "mount":"/media/state",
-        "binds":{
-          "overlays/home":"/home",
-          "overlays/opt":"/opt",
-          "overlays/srv":"/srv",
-          "overlays/var":"/var"
-        }
-      }
-    },
-    "base-usr":{
-      "3":{
-        "label":"USR-A",
-        "mount":"/usr"
-      },
-      "4":{
-        "label":"USR-B"
-      },
-      "9":{
-        "label":"ROOT",
         "fs_type":"btrfs",
         "fs_subvolume":"root",
-        "mount":"/",
-        "binds":{}
+        "mount":"/"
       }
     },
     "vm":{
       "9":{
-        "label":"STATE",
-        "blocks":"6291456"
-      }
-    },
-    "vm-usr":{
-      "3":{
-        "label":"USR-A",
-        "mount":"/usr"
-      },
-      "4":{
-        "label":"USR-B"
-      },
-      "9":{
         "label":"ROOT",
-        "fs_type":"btrfs",
-        "fs_subvolume":"root",
-        "mount":"/",
-        "binds":{},
         "blocks":"6291456"
       }
     },
     "vagrant":{
       "9":{
-        "label":"STATE",
-        "blocks":"33587200"
-      }
-    },
-    "vagrant-usr":{
-      "3":{
-        "label":"USR-A",
-        "mount":"/usr"
-      },
-      "4":{
-        "label":"USR-B"
-      },
-      "9":{
         "label":"ROOT",
-        "fs_type":"btrfs",
-        "fs_subvolume":"root",
-        "mount":"/",
-        "binds":{},
         "blocks":"33587200"
       }
     }

--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -362,7 +362,7 @@ def FormatExt(part, device):
 
   tune_cmd = ['tune2fs', '-L', part['label'], '-e', 'remount-ro']
 
-  if part['type'] in ('coreos-rootfs', 'coreos-usr'):
+  if part['type'] == 'coreos-usr':
     tune_cmd += ['-U', 'clear',
                  '-T', '20091119110000',
                  '-c', '0', '-i', '0', # Disable auto fsck

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -55,11 +55,7 @@ EOF
 
   # Make the filesystem un-mountable as read-write.
   if [ ${FLAGS_enable_rootfs_verification} -eq ${FLAGS_TRUE} ]; then
-    local ro_label="ROOT-A"
-    if [[ "${disk_layout}" == *-usr ]]; then
-      ro_label="USR-A"
-    fi
     "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout="${disk_layout}" \
-      tune --disable2fs_rw "${BUILD_DIR}/${image_name}" "${ro_label}"
+      tune --disable2fs_rw "${BUILD_DIR}/${image_name}" "USR-A"
   fi
 }

--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -2,37 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Files that are known to conflict with /usr but are OK because they
-# are already fixed by toggling the symlink-usr USE flag.
-USR_CONFLICT_WHITELIST=(
-    /bin/awk
-    /bin/basename
-    /bin/chroot
-    /bin/cut
-    /bin/dir
-    /bin/dirname
-    /bin/du
-    /bin/env
-    /bin/expr
-    /bin/gawk
-    /bin/head
-    /bin/mkfifo
-    /bin/mktemp
-    /bin/passwd
-    /bin/readlink
-    /bin/seq
-    /bin/sleep
-    /bin/sort
-    /bin/tail
-    /bin/touch
-    /bin/tr
-    /bin/tty
-    /bin/uname
-    /bin/vdir
-    /bin/wc
-    /bin/yes
-)
-
 test_image_content() {
   local root="$1"
   local returncode=0
@@ -77,37 +46,12 @@ test_image_content() {
     fi
   done
 
-  # Check that the symlink-usr flag agrees with the filesystem state.
-  # Things are likely to break if they don't match.
-  if [[ $(ROOT="${root}" $portageq envvar USE) == *symlink-usr* ]]; then
-    local dir
-    for dir in bin sbin lib32 lib64; do
-      if [[ -d "${root}/usr/${dir}" ]]; then
-        if [[ ! -h "${root}/${dir}" || \
-          $(readlink "${root}/${dir}") != "usr/${dir}" ]]
-        then
-          error "test_image_content: /${dir} is not a symlink to /usr/${dir}"
-          returncode=1
-        fi
-      fi
-    done
-
-    # The whitelist is only required if the use flag is unset
-    USR_CONFLICT_WHITELIST=()
-  fi
-
   # Check that there are no conflicts between /* and /usr/*
   local pkgdb=$(ROOT="${root}" $portageq vdb_path)
   local files=$(awk '$2 ~ /^\/(bin|sbin|lib|lib32|lib64)\// {print $2}' \
                 "${pkgdb}"/*/*/CONTENTS)
   local check_file
   for check_file in $files; do
-    local whitelist
-    for whitelist in "${USR_CONFLICT_WHITELIST[@]}"; do
-      if [[ "${check_file}" == "${whitelist}" ]]; then
-        continue 2
-      fi
-    done
     if grep -q "^... /usr$check_file " "${pkgdb}"/*/*/CONTENTS; then
       error "test_image_content: $check_file conflicts with /usr$check_file"
       returncode=1

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -224,8 +224,7 @@ _disk_ext() {
 }
 
 setup_disk_image() {
-    local suffix=$(portageq-$BOARD envvar COREOS_DISK_LAYOUT_SUFFIX)
-    local disk_layout="${1:-$(_get_vm_opt DISK_LAYOUT)}${suffix}"
+    local disk_layout="${1:-$(_get_vm_opt DISK_LAYOUT)}"
 
     rm -rf "${VM_TMP_DIR}"
     mkdir -p "${VM_TMP_DIR}" "${VM_TMP_ROOT}"


### PR DESCRIPTION
More cleanup now that amd64-generic is gone.
