### PR TITLE
fix(vm_image_util): Don't use the full vagrant OEM on vmware_insecure

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -106,7 +106,7 @@ IMG_vmware_CONF_FORMAT=vmx
 IMG_vmware_insecure_DISK_FORMAT=vmdk_scsi
 IMG_vmware_insecure_DISK_LAYOUT=vm
 IMG_vmware_insecure_CONF_FORMAT=vmware_zip
-IMG_vmware_insecure_OEM_PACKAGE=oem-vagrant
+IMG_vmware_insecure_OEM_PACKAGE=oem-vagrant-key
 
 ## ami
 IMG_ami_BOOT_KERNEL=0


### PR DESCRIPTION
Only the key is needed, and currently the vagrant OEM is completely
broken outside of vagrant. This gets vmware_insecure images back into
the state that they were before cloud config came along. :)
