### PR TITLE
fix(set_lsb_release): Set default GROUP= from arg again.

### DIFF
--- a/build_image
+++ b/build_image
@@ -19,6 +19,7 @@ assert_not_root_user
 
 DEFAULT_GROUP=developer
 if [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
+  # TODO: update to beta, and then stable once those actually exist
   DEFAULT_GROUP=alpha
 fi
 

--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -59,10 +59,9 @@ COREOS_RELEASE_VERSION=$COREOS_VERSION_STRING
 COREOS_RELEASE_BOARD=$FLAGS_board
 EOF
 
-# TODO: update to beta, and then stable once those actually exist
 sudo_clobber "${ROOT_FS_DIR}/usr/share/coreos/update.conf" <<EOF
 SERVER=https://public.update.core-os.net/v1/update/
-GROUP=alpha
+GROUP=$FLAGS_group
 EOF
 
 sudo_clobber "${ROOT_FS_DIR}/etc/coreos/update.conf" <<EOF


### PR DESCRIPTION
This makes sure developer builds stick to the developer group. After
commit c3d07e94 developer PXE/ISO images would report as 'alpha'.
