### PR TITLE
fix(oem/ami): Remove key options, update wrapper for beta

### DIFF
--- a/oem/ami/build_ebs_on_ec2.sh
+++ b/oem/ami/build_ebs_on_ec2.sh
@@ -28,7 +28,7 @@ VERSION="master"
 BOARD="amd64-usr"
 GROUP="alpha"
 IMAGE="coreos_production_ami_image.bin.bz2"
-URL_FMT="http://storage.core-os.net/coreos/%s/%s/$IMAGE"
+GS_URL="gs://storage.core-os.net/coreos"
 IMG_URL=""
 IMG_PATH=""
 
@@ -39,15 +39,14 @@ Options:
     -g GROUP    Set the update group, default is alpha or master
     -p PATH     Path to compressed disk image, overrides -u
     -u URL      URL to compressed disk image, derived from -V if unset.
-    -K KEY      Path to Amazon API private key.
-    -C CERT     Path to Amazon API key certificate.
+    -s STORAGE  GS URL for Google storage (used to generate URL)
     -h          this ;-)
     -v          Verbose, see all the things!
 
 This script must be run from an ec2 host with the ec2 tools installed.
 "
 
-while getopts "V:b:g:p:u:K:C:hv" OPTION
+while getopts "V:b:g:p:u:s:hv" OPTION
 do
     case $OPTION in
         V) VERSION="$OPTARG";;
@@ -55,8 +54,7 @@ do
         g) GROUP="$OPTARG";;
         p) IMG_PATH="$OPTARG";;
         u) IMG_URL="$OPTARG";;
-        K) export EC2_PRIVATE_KEY="$OPTARG";;
-        C) export EC2_CERT="$OPTARG";;
+        s) GS_URL="$OPTARG";;
         h) echo "$USAGE"; exit;;
         v) set -x;;
         *) exit 1;;
@@ -77,7 +75,7 @@ if [[ -n "$IMG_PATH" ]]; then
     IMG_URL=$(basename "$IMG_PATH")
 else
     if [[ -z "$IMG_URL" ]]; then
-        IMG_URL=$(printf "$URL_FMT" "$BOARD" "$VERSION")
+        IMG_URL="http://${GS_URL#gs://}/$BOARD/$VERSION/$IMAGE"
     fi
     if ! curl --fail -s --head "$IMG_URL" >/dev/null; then
         echo "$0: Image URL unavailable: $IMG_URL" >&2

--- a/oem/ami/run.sh
+++ b/oem/ami/run.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-BOARD="$1"
+BOARD="amd64-usr"
+GROUP="$1"
 VER="$2"
 DIR=/home/ubuntu/official
 
-if [ -z "$BOARD" -o -z "$VER" ]; then
-  echo "Usage: $0 amd64-usr 1.2.3" >&2
+if [ -z "$GROUP" -o -z "$VER" ]; then
+  echo "Usage: $0 alpha 1.2.3" >&2
   exit 1
 fi
 
 set -e
-args=( -b $BOARD -V $VER -K $DIR/aws-pk.pem -C $DIR/aws-cert.pem )
-sudo $DIR/build_ebs_on_ec2.sh "${args[@]}"
-$DIR/test_ami.sh -v "${args[@]}"
-$DIR/copy_ami.sh "${args[@]}"
-$DIR/upload_ami_txt.sh "${args[@]}"
+args="-b $BOARD -g $GROUP -V $VER"
+sudo bash -c ". $DIR/marineam-auth.sh && $DIR/build_ebs_on_ec2.sh ${args}"
+source $DIR/marineam-auth.sh
+$DIR/test_ami.sh -v ${args}
+$DIR/copy_ami.sh ${args}
+$DIR/upload_ami_txt.sh ${args}

--- a/oem/ami/test_ami.sh
+++ b/oem/ami/test_ami.sh
@@ -16,8 +16,6 @@ USAGE="Usage: $0 -a ami-id
     -V VERSION  Find AMI by CoreOS version.
     -b BOARD    Set to the board name, default is amd64-usr
     -g GROUP    Set the update group, default is alpha
-    -K KEY      Path to Amazon API private key.
-    -C CERT     Path to Amazon API key certificate.
     -h          this ;-)
     -v          Verbose, see all the things!
 
@@ -30,15 +28,13 @@ VER=
 BOARD="amd64-usr"
 GROUP="alpha"
 
-while getopts "a:V:b:g:K:C:hv" OPTION
+while getopts "a:V:b:g:hv" OPTION
 do
     case $OPTION in
         a) AMI="$OPTARG";;
         V) VER="$OPTARG";;
         b) BOARD="$OPTARG";;
         g) GROUP="$OPTARG";;
-        K) export EC2_PRIVATE_KEY="$OPTARG";;
-        C) export EC2_CERT="$OPTARG";;
         h) echo "$USAGE"; exit;;
         v) set -x;;
         *) exit 1;;


### PR DESCRIPTION
The key/cert authentication method doesn't work any more, just rely on
sourcing a file with the right env vars exported.

Re-enable parallel copy.

Add group option to wrapper and custom google storage url options.
