### PR TITLE
fix(build_image_util): Reorder when set_lsb_release is called

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -67,13 +67,9 @@ create_dev_image() {
   info "Building developer image ${image_name}"
   local root_fs_dir="${BUILD_DIR}/rootfs"
 
-  start_image "${image_name}" "${disk_layout}" "${root_fs_dir}"
+  start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 
   emerge_to_image "${root_fs_dir}" coreos-base/coreos-dev
-
-  "${BUILD_LIBRARY_DIR}/set_lsb_release" \
-    --root="${root_fs_dir}" \
-    --board="${BOARD}"
 
   # Setup portage for emerge and gmerge
   configure_dev_portage "${root_fs_dir}" "${devserver}"
@@ -96,5 +92,5 @@ EOF
   # The remount services are provided by coreos-base/coreos-init
   systemd_enable "${root_fs_dir}" "local-fs.target" "remount-usr.service"
 
-  finish_image "${disk_layout}" "${root_fs_dir}" "${update_group}"
+  finish_image "${disk_layout}" "${root_fs_dir}"
 }

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -33,7 +33,7 @@ create_prod_image() {
   info "Building production image ${image_name}"
   local root_fs_dir="${BUILD_DIR}/rootfs"
 
-  start_image "${image_name}" "${disk_layout}" "${root_fs_dir}"
+  start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 
   # Install minimal GCC (libs only) and then everything else
   emerge_prod_gcc "${root_fs_dir}"
@@ -69,7 +69,7 @@ EOF
     disable_read_write=${FLAGS_FALSE}
   fi
 
-  finish_image "${disk_layout}" "${root_fs_dir}" "${update_group}"
+  finish_image "${disk_layout}" "${root_fs_dir}"
 
   # Make the filesystem un-mountable as read-write.
   if [[ ${disable_read_write} -eq ${FLAGS_TRUE} ]]; then


### PR DESCRIPTION
dev_image_util needs to be able to append to update.conf so move
set_lsb_release to start_image instead of finish_image.

Related: https://github.com/coreos/docs/pull/212 and https://github.com/coreos/dev-util/pull/12
