### PR TITLE
fix(disk_layout): Bump up default ROOT volume sizes for btrfs.

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -62,7 +62,7 @@
       "9":{
         "label":"ROOT",
         "type":"coreos-resize",
-        "blocks":"1048576",
+        "blocks":"4194304",
         "fs_type":"btrfs",
         "fs_subvolume":"root",
         "mount":"/"
@@ -71,7 +71,7 @@
     "vm":{
       "9":{
         "label":"ROOT",
-        "blocks":"6291456"
+        "blocks":"12582912"
       }
     },
     "vagrant":{

--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -342,11 +342,6 @@ def FormatBtrfs(part, device):
   """
   Sudo(['mkfs.btrfs', '--byte-count', part['fs_bytes'],
                       '--label', part['label'],
-                      # must use mixed chunks at this point because
-                      # the filesystem size is too small.
-                      '--data', 'single',
-                      '--metadata', 'single',
-                      '--mixed',
                       device])
 
   if part.get('fs_subvolume', None):


### PR DESCRIPTION
btrfs isn't designed for small volumes and can run out of space sooner
than one would expect in our current setup, particularly with docker.
To try to improve the situation always create the filesystem initially
as 2GB instead of 512MB using the default settings: metadata is
duplicated, data is single, not mixed. For the default vm layout
use 6GB instead of 3GB, about what we use for EC2.
