### PR TITLE
fix(sdk_lib): Remove depot_tools mount

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -178,7 +178,6 @@ cmp_ver() {
 _user="${USER}"
 [[ ${USER} == "root" ]] && _user="${SUDO_USER}"
 _CHROOT_TRUNK_DIRS=( "/home/${_user}/trunk" /mnt/host/source )
-_DEPOT_TOOLS_DIRS=( "/home/${_user}/depot_tools" /mnt/host/depot_tools )
 unset _user
 
 _process_mount_pt() {
@@ -222,11 +221,9 @@ set_chroot_trunk_dir() {
   if [[ ${INSIDE_CHROOT} -eq 0 ]] && [[ -z ${1-} ]]; then
     # Can't do the upgrade, thus skip trying to do so.
     CHROOT_TRUNK_DIR="${_CHROOT_TRUNK_DIRS[1]}"
-    DEPOT_TOOLS_DIR="${_DEPOT_TOOLS_DIRS[1]}"
     return
   fi
   _process_mount_pt "$1" CHROOT_TRUNK_DIR "${_CHROOT_TRUNK_DIRS[@]}" ${2:+true}
-  _process_mount_pt "$1" DEPOT_TOOLS_DIR "${_DEPOT_TOOLS_DIRS[@]}" ${2:+true}
 }
 
 set_chroot_trunk_dir

--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -372,12 +372,6 @@ setup_env() {
       done
     fi
 
-    # A reference to the DEPOT_TOOLS path may be passed in by cros_sdk.
-    if [ -n "${DEPOT_TOOLS}" ]; then
-      debug "Mounting depot_tools"
-      setup_mount "${DEPOT_TOOLS}" --bind "${DEPOT_TOOLS_DIR}"
-    fi
-
     # Mount GnuPG's data directory for signing uploads
     if [[ -d "$SUDO_HOME/.gnupg" ]]; then
       debug "Mounting GnuPG"

--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -218,12 +218,12 @@ EOF
    ln -s ../../cache/chromeos-cache/distfiles/target \
      "${FLAGS_chroot}/var/lib/portage/distfiles-target"
 
-   # Add chromite/bin and depot_tools into the path globally; note that the
-   # chromite wrapper itself might also be found in depot_tools.
+   # Add chromite/bin into the path globally
    # We rely on 'env-update' getting called below.
    target="${FLAGS_chroot}/etc/env.d/99coreos"
    cat <<EOF > "${target}"
-PATH=${CHROOT_TRUNK_DIR}/chromite/bin:${DEPOT_TOOLS_DIR}
+PATH=${CHROOT_TRUNK_DIR}/chromite/bin
+ROOTPATH=${CHROOT_TRUNK_DIR}/chromite/bin
 CROS_WORKON_SRCROOT="${CHROOT_TRUNK_DIR}"
 PORTAGE_USERNAME=${SUDO_USER}
 EOF
@@ -349,8 +349,7 @@ else
   # Reset internal vars to force them to the 'inside the chroot' value;
   # since user directories now exist, this can do the upgrade in place.
   set_chroot_trunk_dir "${FLAGS_chroot}" poppycock
-  mkdir -p "${FLAGS_chroot}/${CHROOT_TRUNK_DIR}" \
-      "${FLAGS_chroot}/${DEPOT_TOOLS_DIR}" "${FLAGS_chroot}/run"
+  mkdir -p "${FLAGS_chroot}/${CHROOT_TRUNK_DIR}" "${FLAGS_chroot}/run"
 
   # Run all the init stuff to setup the env.
   init_setup


### PR DESCRIPTION
We now include repo in the SDK which was the only thing from depot_tools
that we depended on.

Related: https://github.com/coreos/coreos-overlay/pull/638
