### PR TITLE
fix(build_library): Finish conversion to new bucket layout.

### DIFF
--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -103,7 +103,7 @@ upload_packages() {
     [[ -n "${BOARD}" ]] || die "board_options.sh must be sourced first"
 
     local board_packages="${1:-"${BOARD_ROOT}/packages"}"
-    local def_upload_path="${UPLOAD_ROOT}/${BOARD}/${COREOS_VERSION_STRING}"
+    local def_upload_path="${UPLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION_STRING}"
     upload_files packages ${def_upload_path} "pkgs/" "${board_packages}"/*
 }
 
@@ -178,7 +178,7 @@ upload_image() {
     uploads+=( "${sigs[@]}" )
 
     local log_msg=$(basename "$digests" .DIGESTS)
-    local def_upload_path="${UPLOAD_ROOT}/${BOARD}/${COREOS_VERSION_STRING}"
+    local def_upload_path="${UPLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION_STRING}"
     upload_files "${log_msg}" "${def_upload_path}" "" "${uploads[@]}"
 }
 
@@ -191,7 +191,7 @@ download_image_url() {
     fi
 
     local download_root="${FLAGS_download_root:-${UPLOAD_ROOT}}"
-    local download_path="${download_root%%/}/${BOARD}/${COREOS_VERSION_STRING}"
+    local download_path="${download_root%%/}/boards/${BOARD}/${COREOS_VERSION_STRING}"
     if [[ -n "${FLAGS_download_path}" ]]; then
         download_path="${FLAGS_download_path%%/}"
     fi

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -795,7 +795,7 @@ vm_upload() {
         cp "${digests}.asc" "${legacy_digests}.asc"
     fi
 
-    local def_upload_path="${UPLOAD_ROOT}/${BOARD}/${COREOS_VERSION_STRING}"
+    local def_upload_path="${UPLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION_STRING}"
     upload_files "$(_dst_name)" "${def_upload_path}" "" "${legacy_uploads[@]}"
 }
 

--- a/core_promote
+++ b/core_promote
@@ -63,7 +63,7 @@ roller_channel="${FLAGS_channel^}"
 lower_channel="${FLAGS_channel,,}"
 
 # Full GS URL of the original build
-gs_build="${FLAGS_build_storage}/${lower_channel}/${FLAGS_board}/${FLAGS_version}"
+gs_build="${FLAGS_build_storage}/${lower_channel}/boards/${FLAGS_board}/${FLAGS_version}"
 
 if [[ -z "${FLAGS_release_storage}" ]]; then
     FLAGS_release_storage="gs://${lower_channel}.release.core-os.net"

--- a/oem/ami/build_ebs_on_ec2.sh
+++ b/oem/ami/build_ebs_on_ec2.sh
@@ -75,7 +75,7 @@ if [[ -n "$IMG_PATH" ]]; then
     IMG_URL=$(basename "$IMG_PATH")
 else
     if [[ -z "$IMG_URL" ]]; then
-        IMG_URL="$GS_URL/$GROUP/$BOARD/$VERSION/$IMAGE"
+        IMG_URL="$GS_URL/$GROUP/boards/$BOARD/$VERSION/$IMAGE"
     fi
     if [[ "$IMG_URL" == gs://* ]]; then
         if ! gsutil -q stat "$IMG_URL"; then

--- a/oem/ami/upload_ami_txt.sh
+++ b/oem/ami/upload_ami_txt.sh
@@ -72,7 +72,7 @@ done
 
 OUT=
 for r in "${!AMIS[@]}"; do
-    url="$GS_URL/$GROUP/$BOARD/$VER/${IMAGE}_${r}.txt"
+    url="$GS_URL/$GROUP/boards/$BOARD/$VER/${IMAGE}_${r}.txt"
     tmp=$(mktemp --suffix=.txt)
     trap "rm -f '$tmp'" EXIT
     echo "${AMIS[$r]}" > "$tmp"


### PR DESCRIPTION
I started to move board files under a boards/ directory similar to how
the SDK is under sdk/ but didn't do so everywhere. This should finish
the job so everything is consistent now.

Note: This prefix is only used in developer and buildbot uploads. When
final releases are copied to $channel.release.core-os.net it doesn't use
the prefix since a) I already published urls without the prefix and b)
no sdk files are ever posted to the public release locations.
