### PR TITLE
fix(upload_ami_txt): One missed URL fixup

### DIFF
--- a/oem/ami/upload_ami_txt.sh
+++ b/oem/ami/upload_ami_txt.sh
@@ -84,7 +84,7 @@ for r in "${!AMIS[@]}"; do
         OUT="${OUT}|${r}=${AMIS[$r]}"
     fi
 done
-url="$GS_URL/$GROUP/$BOARD/$VER/${IMAGE}_all.txt"
+url="$GS_URL/$GROUP/boards/$BOARD/$VER/${IMAGE}_all.txt"
 tmp=$(mktemp --suffix=.txt)
 trap "rm -f '$tmp'" EXIT
 echo "$OUT" > "$tmp"


### PR DESCRIPTION
I added boards to the path for the other files but not ami_all.txt :(
