### PR TITLE
feat(metadata): Add support for updating ebuild metadata cache

### DIFF
--- a/update_ebuilds
+++ b/update_ebuilds
@@ -20,6 +20,8 @@ DEFINE_string rsync "rsync://rsync.gentoo.org/gentoo-portage" \
     "Rsync location for gentoo-portage to use with --portage=rsync"
 DEFINE_boolean commit ${FLAGS_FALSE} \
     "Commit all changes after updating portage-stable."
+DEFINE_boolean regencache ${FLAGS_TRUE} \
+    "Regenerate cache for updated ebuilds."
 
 
 # Parse flags
@@ -34,6 +36,11 @@ fi
 
 if [[ -z "$*" ]]; then
     die "No packages provided"
+fi
+
+# eclass updates impact coreos-overlay too, use update_metadata.
+if [[ "$*" == *eclass* ]]; then
+    FLAGS_regencache=${FLAGS_FALSE}
 fi
 
 export CVSROOT="${FLAGS_cvsroot}"
@@ -52,7 +59,7 @@ for pkg in "$@"; do
     else
         if [[ "$FLAGS_portage" == rsync ]]; then
             FLAGS_portage="${FLAGS_rsync}"
-	fi
+        fi
         mkdir -p "$pkg"
         rsync $RSYNC_OPTS -v --exclude CVS "$FLAGS_portage/$pkg/" "$pkg"
     fi
@@ -64,7 +71,11 @@ for pkg in "$@"; do
 
     git add -A "$pkg"
 
-    # TODO(marineam): Update metadata directory?
+    # Sync up the ebuild metadata cache
+    if [[ $FLAGS_regencache -eq $FLAGS_TRUE && "$pkg" == */* ]]; then
+        egencache --repo=portage-stable --update "$pkg"
+        git add -A "metadata/md5-cache/${pkg}-*"
+    fi
 done
 
 if [[ $FLAGS_commit -eq $FLAGS_TRUE ]]; then
@@ -81,4 +92,8 @@ EOF
     fi
 else
     git status
+fi
+
+if [[ "$*" == *eclass* ]]; then
+    info "Please run update_metadata to update cache in all overlays."
 fi

--- a/update_metadata
+++ b/update_metadata
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright (c) 2014 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+SCRIPT_ROOT=$(dirname $(readlink -f "$0"))
+. "${SCRIPT_ROOT}/common.sh" || exit 1
+
+DEFINE_boolean commit ${FLAGS_FALSE} \
+    "Commit all changes after updating."
+
+# Parse flags
+FLAGS "$@" || exit 1
+eval set -- "${FLAGS_ARGV}"
+switch_to_strict_mode
+
+if [[ $# -eq 0 ]]; then
+    eval set -- portage-stable coreos
+fi
+
+update_overlay() {
+    local repo_name="$1"
+    local repo_path=$(portageq get_repo_path / "${repo_name}")
+    local job_opts=$(portageq envvar MAKEOPTS)
+
+    info "Updating metadata in ${repo_name}..."
+    egencache ${job_opts} --repo="${repo_name}" --update
+
+    pushd "${repo_path}" >/dev/null
+    git add -A metadata/md5-cache
+    if [[ ${FLAGS_commit} -eq ${FLAGS_TRUE} ]]; then
+        git commit -m "chore(metadata): Regenerate cache" metadata/md5-cache
+    else
+        git status metadata/md5-cache
+    fi
+    popd >/dev/null
+}
+
+for repo in "$@"; do
+    if ! portageq get_repo_path / "$repo" >/dev/null; then
+        die_notrace "Unknown repo name '$repo'"
+    fi
+    update_overlay "$repo"
+done
+
+command_completed


### PR DESCRIPTION
New script update_metadata to do a global update of both repos.
Add support to update_ebuilds to do incremental updates when just
pulling new ebuilds into portage-stable.

First refresh of the cache is in https://github.com/coreos/coreos-overlay/pull/677 and https://github.com/coreos/portage-stable/pull/115

This speeds up the first emerge command in a fresh environment quite a bit.
