### PR TITLE
feat(OpenStack): Add new scripts to support OpenStack OEM handling

### DIFF
--- a/oem/generic/check_etag.sh
+++ b/oem/generic/check_etag.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# check_etag.sh
+#
+# A tool for monitoring remote files and acting if the file has changed
+# This tool has been optimized for use on CoreOS but should work 
+# for most files where an ETag is exposed.
+ 
+# by default we retrieve the alpha image, set to  a different value to retrieve
+# that release
+
+set -e -o pipefail
+ 
+release=${1:-"alpha"}
+if [[ $1 != http* ]]; then
+  url="http://storage.core-os.net/coreos/amd64-usr/$release/version.txt"
+else
+  url=$1
+  release=$(echo ${url} | sed -e 's/http:\/\///1' -e 's/\//-/g' )
+fi
+tmplocation="/tmp/etagsync"
+ 
+mkdir -p ${tmplocation}
+pushd ${tmplocation} > /dev/null 2>&1
+ 
+remote_etag=$(curl -I ${url} -k -s  | \
+  gawk '/ETag/ {print gensub("\"", "", "g", $2)}')
+ 
+source ${release}_etag > /dev/null 2>&1
+ 
+if [ "$remote_etag" == "$local_etag" ]; then
+  echo "Everything is current"
+  exit 0
+else
+  echo "Time to sync things!"
+  echo "local_etag=$remote_etag" > ${release}_etag
+  exit 1
+fi
+
+popd > /dev/null 2>&1
+
+# vim: set ts=2 sw=2 expandtab:

--- a/oem/openstack/README.md
+++ b/oem/openstack/README.md
@@ -1,0 +1,37 @@
+#OpenStack OEM utils
+
+##About
+
+These scripts are used to manage loading CoreOS images into an OpenStack
+deployment.  All scripts here should be considered in the public domain.
+
+Outside of this directory is a "generic" scripts directory.  This is the
+location of any scripts not specific to any OEM.  There you will find useful
+scripts like `check_etag.sh`.
+
+To load images in an automated fashion via `python-glanceclient`, one may
+use a cron job which will check the ETag on the remote file on the CoreOS
+image storage then proceed with executing this script.
+
+
+##Example Usage
+
+First, load your openstack credentials using one of the following methods:
+
+```
+$ source ~/.openstack/keystonerc_${USERNAME}
+```
+
+```
+$ export OS_PASSWORD=secure_password
+$ export OS_AUTH_URL=http://my.keystone.auth-url.example.com:35357/v2.0/
+$ export OS_USERNAME=redbeard
+$ export OS_TENANT_NAME=coreos
+```
+
+Next, run the actual synchronization script:
+
+```
+$ ../generic/check_etag.sh && echo "Everything synced" || ./glance_load.sh
+```
+

--- a/oem/openstack/glance_load.sh
+++ b/oem/openstack/glance_load.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# glance_load.sh
+#
+# A tool for loading a remote image into an OpenStack glance image store.
+# This tool has been optimized for use on CoreOS but should work for most files
+# where an ETag is exposed.
+#
+# You will need to source your glance credentials before using this script
+#
+# By default we retrieve the alpha image, set to  a different value to retrieve
+# that release
+
+set -e -o pipefail
+
+release=${1:-"alpha"}
+if [[ "$1" != http* ]]; then
+  baseurl="http://${release}.release.core-os.net/amd64-usr/current"
+else
+  # for this convoluded trick, we take an arbitrary URL, chop it up, and try
+  # to turn it into usable input for the rest of the script.
+
+  # this is based on urls of the form:
+  # http://storage.core-os.net/coreos/amd64-usr/master/version.txt 
+  # where the following sed expression extracts the "master" portion
+  baseurl="${1%/*}"
+  release="${baseurl##*/}"
+fi
+version_url="${baseurl}/version.txt"
+image_url="${baseurl}/coreos_production_openstack_image.img.bz2"
+
+# use the following location as our local work space
+tmplocation=$(mktemp -d /var/tmp/glanceload.XXX)
+pushd ${tmplocation} > /dev/null 2>&1
+
+curl --fail -s -L -O ${version_url}
+. version.txt
+ 
+# if we already have the image don't waste time
+if glance image-show "CoreOS-${release}-v${COREOS_VERSION}"; then
+  echo "Image already exists."
+  rm -rf ${tmplocation}
+  exit 
+fi
+
+coreosimg="coreos_${COREOS_VERSION}_openstack_image.img"
+
+# change the following line to reflect the image to be chosen, openstack
+#  is used by default
+curl --fail -s -L ${image_url} |  bunzip2 > ${coreosimg}
+ 
+# perform actual image creation
+#  here we set the os_release, os_verison, os_family, and os_distro variables
+#  for intelligent consumption of images by scripts
+glance image-create --name CoreOS-${release}-v${COREOS_VERSION} --progress \
+  --is-public true --property os_distro=coreos --property os_family=coreos \
+  --property os_version=${COREOS_VERSION} \
+  --disk-format qcow2 --container-format bare --min-disk 6 --file $coreosimg
+
+# optionally, set --property os_release=${release} in the glance image-create
+# command above and uncomment the two commands below to support searching by
+# current channel as per CoreOS
+#  
+# grab UUID of newly created image
+# new_glance_uuid=$(glance image-show CoreOS-${release}-v${COREOS_VERSION} | \
+#  gawk '/ id / {print $4}')
+
+
+# purge all previous tags on releases
+#glance image-list --property "os_release=$release" \
+#  | gawk '$4 ~ /CoreOS/ && !/'"$new_glance_uuid"'/ {printf \
+#  "glance image-update --property os_distro=coreos --property \
+#  os_family=coreos --property os_version=%s --purge-props %s \n",\
+#  gensub(/CoreOS_v/, "", "g", $4), $2}' | sh
+
+popd > /dev/null 2>&1
+
+rm -rf ${tmplocation}
+
+# vim: set ts=2 sw=2 expandtab:


### PR DESCRIPTION
Included are scripts to monitor the CoreOS remote etag, as well as
load a new image into a OpenStack Glance image store.
