### PR TITLE
fix(build_image): Use developer_data as a system config.

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -198,8 +198,8 @@ finish_image() {
     local data_path="/usr/share/coreos/developer_data"
     local unit_path="usr-share-coreos-developer_data"
     sudo cp "${FLAGS_developer_data}" "${root_fs_dir}/${data_path}"
-    systemd_enable "${root_fs_dir}" user-config.target \
-        "user-cloudinit@.path" "user-cloudinit@${unit_path}.path"
+    systemd_enable "${root_fs_dir}" system-config.target \
+        "system-cloudinit@.service" "system-cloudinit@${unit_path}.service"
   fi
 
   write_contents "${root_fs_dir}" "${BUILD_DIR}/${image_contents}"


### PR DESCRIPTION
Evaluating this as a user config causes it to block on
coreos-environment-setup.service which will wait on networking. This
makes it hard to add extra tricks for testing/debugging situations where
networking is failing. For example, to trigger dhcpcd if networkd dies:

```
#cloud-config

write_files:
  - path: /etc/systemd/system/systemd-networkd.service.d/dhcpcd.conf
    content: |
      [Unit]
      OnFailure=dhcpcd.service

      [Service]
      Restart=no
```
