### PR TITLE
configure_bootloaders: only add a single serial console boot arg

### DIFF
--- a/build_library/configure_bootloaders.sh
+++ b/build_library/configure_bootloaders.sh
@@ -83,7 +83,11 @@ configure_syslinux() {
 
   # Add ttyS0 as a secondary console, useful for qemu -nographic
   # This leaves /dev/console mapped to tty0 (vga) which is reasonable default.
-  syslinux_args="console=ttyS0,115200n8 ${common_args}"
+  if [[ ${common_args} == *console=ttyS* ]] ; then
+    syslinux_args="${common_args}"
+  else
+    syslinux_args="console=ttyS0,115200n8 ${common_args}"
+  fi
 
   sudo_clobber "${SYSLINUX_DIR}/syslinux.cfg" <<EOF
 SERIAL 0 115200


### PR DESCRIPTION
Only one console of each type (virtual, serial, etc.) is supported
in the boot args. Only add ttyS0 if no other serial consoles have
been provided.
