### PR TITLE
make_chroot: Do not fail if user has strange PATH

### DIFF
--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -9,6 +9,8 @@
 # setup for development. Once created, the password is set to PASSWORD (below).
 # One can enter the chrooted environment for work by running enter_chroot.sh.
 
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 SCRIPT_ROOT=$(readlink -f $(dirname "$0")/..)
 . "${SCRIPT_ROOT}/common.sh" || exit 1
 


### PR DESCRIPTION
PATH is inherited by the processes running inside the chroot when doing make_chroot.

So set a sane PATH in the script to unbreak chroot creation for users of e.g. archlinux where PATH can be safely set to /usr/bin, which will not work to find e.g. addgroup in the gentoo chroot.
