### PR TITLE
vm_image: switch xen disk format back to raw

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -85,7 +85,6 @@ IMG_qemu_no_kexec_CONF_FORMAT=qemu
 
 ## xen
 IMG_xen_BOOT_KERNEL=0
-IMG_xen_DISK_FORMAT=vhd
 IMG_xen_CONF_FORMAT=xl
 
 ## virtualbox


### PR DESCRIPTION
VHD was just for testing, raw is more useful for published images.
coreos-install will now be able to install working xen instances:

```
coreos-install -d /dev/xvda -o xen -c cloud-config.yml
```
