### PR TITLE
ami: fix generating ami lists

### DIFF
--- a/oem/ami/run.sh
+++ b/oem/ami/run.sh
@@ -3,7 +3,7 @@
 BOARD="amd64-usr"
 GROUP="$1"
 VER="$2"
-DIR=/home/ubuntu/official
+DIR=/home/ec2-user/scripts
 
 if [ -z "$GROUP" -o -z "$VER" ]; then
   echo "Usage: $0 alpha 1.2.3" >&2

--- a/oem/ami/upload_ami_txt.sh
+++ b/oem/ami/upload_ami_txt.sh
@@ -85,19 +85,20 @@ upload_file() {
     echo "OK, ${url}=${content}"
 }
 
+PV_ALL=""
 for r in "${!AMIS[@]}"; do
     upload_file "$r" "${AMIS[$r]}"
     upload_file "pv_$r" "${AMIS[$r]}"
+    PV_ALL+="|${r}=${AMIS[$r]}"
 done
+PV_ALL="${PV_ALL#|}"
+
+HVM_ALL=""
 for r in "${!HVM_AMIS[@]}"; do
     upload_file "hvm_$r" "${HVM_AMIS[$r]}"
+    HVM_ALL+="|${r}=${HVM_AMIS[$r]}"
 done
-
-ofs="$IFS"
-IFS="|$IFS"
-PV_ALL="${AMIS[*]}"
-HVM_ALL="${HVM_AMIS[*]}"
-IFS="$ofs"
+HVM_ALL="${HVM_ALL#|}"
 
 upload_file "all" "${PV_ALL}"
 upload_file "pv" "${PV_ALL}"


### PR DESCRIPTION
Dropped the region= prefixes by mistake.
