### PR TITLE
bootstrap_sdk: setup /usr/lib correctly before calling set_lsb_release

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -58,7 +58,12 @@ check_gsutil_opts
 if [[ "$STAGES" =~ stage4 ]]; then
     info "Setting release to ${COREOS_VERSION_STRING}"
     rm -rf "${TEMPDIR}/stage4_overlay"
-    mkdir -p "${TEMPDIR}/stage4_overlay"
+    # need to setup the lib->lib64 symlink correctly
+    libdir=$(get_sdk_libdir)
+    mkdir -p "${TEMPDIR}/stage4_overlay/usr/${libdir}"
+    if [[ "${libdir}" != lib ]]; then
+        ln -s "${libdir}" "${TEMPDIR}/stage4_overlay/usr/lib"
+    fi
     "${BUILD_LIBRARY_DIR}/set_lsb_release" \
         --root "${TEMPDIR}/stage4_overlay"
 fi

--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -135,6 +135,11 @@ get_sdk_profile() {
     echo "coreos:coreos/$(get_sdk_arch)/sdk"
 }
 
+get_sdk_libdir() {
+    # Looking for LIBDIR_amd64 or similar
+    portageq envvar "LIBDIR_$(get_sdk_arch)"
+}
+
 # Usage: get_sdk_binhost [version...]
 # If no versions are specified the current and SDK versions are used.
 get_sdk_binhost() {


### PR DESCRIPTION
os-release is now written to /usr/lib but that is likely a symlink to
/usr/lib64 so a little extra logic is required to avoid clobbering the
symlink.
