### PR TITLE
ami: configure etcd with public addresses

### DIFF
--- a/oem/ami/test_ami.sh
+++ b/oem/ami/test_ami.sh
@@ -96,8 +96,8 @@ userdata="#cloud-config
 coreos:
     etcd:
         discovery: $discovery
-        addr: \$private_ipv4:4001
-        peer-addr: \$private_ipv4:7001
+        addr: \$public_ipv4:4001
+        peer-addr: \$public_ipv4:7001
     units:
       - name: etcd.service
         command: start


### PR DESCRIPTION
When I created the new AMI build host I just accepted the default
'wizard' security group which seems to have placed the host in a VPC.
There doesn't seem to be a way to fix this and as-is the build host
cannot access the private addresses on the test VMs it launches.
Switching to the public ones work fine though. Didn't notice this at
first because it is only a problem when etcd sends a redirect.
