### PR TITLE
qemu: set DHCP hostname based on image name and version

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -175,6 +175,6 @@ qemu-system-x86_64 \
     -m ${VM_MEMORY} \
     -machine accel=kvm:tcg \
     -net nic,vlan=0,model=virtio \
-    -net user,vlan=0,hostfwd=tcp::"${SSH_PORT}"-:22 \
+    -net user,vlan=0,hostfwd=tcp::"${SSH_PORT}"-:22,hostname="${VM_NAME}" \
     "$@"
 exit $?

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -196,6 +196,10 @@ set_vm_paths() {
     VM_TMP_ROOT="${VM_TMP_DIR}/rootfs"
     VM_NAME="$(_src_to_dst_name "${src_name}" "")-${COREOS_VERSION_STRING}"
     VM_README="${dst_dir}/$(_src_to_dst_name "${src_name}" ".README")"
+
+    # Make VM_NAME safe for use as a hostname
+    VM_NAME="${VM_NAME//./-}"
+    VM_NAME="${VM_NAME//+/-}"
 }
 
 _get_vm_opt() {


### PR DESCRIPTION
Provides an easy way to test this setting hostname from DHCP, most other
systems rely on it.
