### PR TITLE
setup_board: fix fetching binary toolchain packages

### DIFF
--- a/setup_board
+++ b/setup_board
@@ -265,7 +265,7 @@ if [[ ${FLAGS_regen_configs} -eq ${FLAGS_FALSE} ]]; then
         "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]]
   then
     EMERGE_FLAGS+=" --usepkg --getbinpkg"
-    EMERGE_TOOLCHAIN_FLAGS+=" --usepkgonly"
+    EMERGE_TOOLCHAIN_FLAGS+=" --usepkgonly --getbinpkg"
   else
     # When binary packages are disabled we need to make sure the cross
     # sysroot includes any build dependencies for the toolchain.


### PR DESCRIPTION
Fix 98684560 which in turn tried to fix 0d29e735. This time the option
to download binary packages was lost so building from scratch worked but
not the normal usage of using binary packages. _sigh_
