### PR TITLE
amis: switch back to sda for root PV volume, add publish wrapper

### DIFF
--- a/oem/ami/build_ebs_on_ec2.sh
+++ b/oem/ami/build_ebs_on_ec2.sh
@@ -178,9 +178,9 @@ amiid=$(ec2-register                                  \
   --architecture "$arch"                              \
   --virtualization-type paravirtual                   \
   --kernel "$akiid"                                   \
-  --root-device-name /dev/xvda                        \
-  --block-device-mapping /dev/xvda=$snapshotid::true  \
-  --block-device-mapping /dev/xvdb=ephemeral0         |
+  --root-device-name /dev/sda                         \
+  --block-device-mapping /dev/sda=$snapshotid::true   \
+  --block-device-mapping /dev/sdb=ephemeral0          |
   cut -f2)
 
 cat <<EOF

--- a/oem/ami/prod-publish.sh
+++ b/oem/ami/prod-publish.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BOARD="amd64-usr"
+GROUP="$1"
+VER="$2"
+DIR=/home/ec2-user/scripts
+
+if [ -z "$GROUP" -o -z "$VER" ]; then
+  echo "Usage: $0 alpha 1.2.3" >&2
+  exit 1
+fi
+
+set -e
+source $DIR/marineam-auth.sh
+$DIR/publish_ami.sh -b $BOARD -g $GROUP -V $VER"


### PR DESCRIPTION
If additional EBS volumes are mapped to a PV instance using a "sd_" name
they will always be ordered by the hypervisor before "xvd_" devices,
again ignoring the root device definition. This applies to all PV
instance types so we cannot get away with just poo-pooing m1.small.

We will need to call attention to this since it requires users who set
the volume size via APIs to use the name "/dev/sda" again.
