### PR TITLE
make_chroot: don't enable git-prompt via bashcomp

### DIFF
--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -361,9 +361,6 @@ if [[ "${FLAGS_jobs}" -ne -1 ]]; then
 fi
 enter_chroot "${CHROOT_TRUNK_DIR}/src/scripts/update_chroot" "${UPDATE_ARGS[@]}"
 
-# Enable git terminal prompt
-early_enter_chroot eselect bashcomp enable --global git-prompt
-
 CHROOT_EXAMPLE_OPT=""
 if [[ "$FLAGS_chroot" != "$DEFAULT_CHROOT_DIR" ]]; then
   CHROOT_EXAMPLE_OPT="--chroot=$FLAGS_chroot"


### PR DESCRIPTION
Newer git ebuilds have decided that the "git-prompt" script isn't really
bash completion so stopped installing it via that mechanism. Instead it
installed it started installing it in /usr/share/docs which gets
compressed by default and the path is based on ebuild version. The path
changed again in 1.9.3 to /usr/share/git and didn't compress it so that
makes it actually possibly usable but 1.9.3 or later isn't stable yet.

We can re-enable it the next time git gets updated but not worth fussing
over the current brokenness right now.
