### PR TITLE
sdk: assert host system is running Linux 3.7 or later

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -464,6 +464,17 @@ assert_root_user() {
   fi
 }
 
+# We depend on some relatively modern kernel features, in particular a
+# reasonably recent btrfs version is required to generate images.
+# Current requirement: 3.7 added btrfs' extref incompat feature
+assert_kernel_version() {
+  local req_kv="3.7"
+  local cur_kv=$(uname -r)
+  if ! cmp_ver ge "${cur_kv}" "${req_kv}"; then
+    die_notrace "Detected kernel ${cur_kv}, ${req_kv} or later is required"
+  fi
+}
+
 # Check that all arguments are flags; that is, there are no remaining arguments
 # after parsing from shflags.  Allow (with a warning) a single empty-string
 # argument.

--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -12,6 +12,7 @@ SCRIPT_ROOT=$(readlink -f $(dirname "$0")/..)
 # Script must be run outside the chroot and as root.
 assert_outside_chroot
 assert_root_user
+assert_kernel_version
 
 # Define command line flags
 # See http://code.google.com/p/shflags/wiki/Documentation10x

--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -29,6 +29,7 @@ fi
 # Script must be run outside the chroot and as root.
 assert_outside_chroot
 assert_root_user
+assert_kernel_version
 
 # Define command line flags.
 # See http://code.google.com/p/shflags/wiki/Documentation10x


### PR DESCRIPTION
Currently building images on older kernels will fail because mkfs.btrfs
enables an incompatible feature 'extref' by default. We never really
made this requirement explicit and the SDK in general has continued to
maintain compatibility with older kernels. Make the requirement explicit
so users will get errors quicker and there is a clear line for what
kernel features can be used in the SDK.
