### PR TITLE
build_image_util: fix generation of packages.txt

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -147,9 +147,8 @@ write_contents() {
 write_packages() {
     local profile="${BUILD_DIR}/configroot/etc/portage/profile"    
     info "Writing ${2##*/}"
-    ROOT="$1" equery-$BOARD --no-color \
-        list '*' --format '$cpv::$repo' \
-        > "$2"
+    ROOT="$1" PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
+        equery --no-color list '*' --format '$cpv::$repo' > "$2"
     if [[ -f "${profile}/package.provided" ]]; then
         cat "${profile}/package.provided" >> "$2"
     fi


### PR DESCRIPTION
The passing ROOT= as an environment variable to board wrapper scripts
doesn't work, the script unconditionally overrides it. This means so far
our packages.txt files have listed the contents of /build/amd64-usr
instead of the image. Fix this by calling equery directly instead.
