### PR TITLE
exoscale builder

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -180,7 +180,6 @@ IMG_cloudstack_vhd_OEM_PACKAGE=oem-cloudstack
 IMG_digitalocean_OEM_PACKAGE=oem-digitalocean
 
 ## exoscale
-IMG_exoscale_BOOT_KERNEL=0
 IMG_exoscale_DISK_FORMAT=qcow2
 IMG_exoscale_OEM_PACKAGE=oem-exoscale
 ###########################################################


### PR DESCRIPTION
This pull request provides the builder support to natively build exoscale compatible images so that they can be published as the CoreOS releases are generated.

requires: https://github.com/coreos/coreos-overlay/pull/843 
