### PR TITLE
Added --oem_pkg option to image_to_vm.sh

### DIFF
--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -40,6 +40,8 @@ DEFINE_boolean prod_image "${FLAGS_FALSE}" \
   "Use the production image instead of the default developer image."
 DEFINE_string to "" \
   "Destination folder for VM output file(s)"
+DEFINE_string oem_pkg "" \
+  "OEM package to install"
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
@@ -55,6 +57,10 @@ check_gsutil_opts
 
 if ! set_vm_type "${FLAGS_format}"; then
     die_notrace "Invalid format: ${FLAGS_format}"
+fi
+
+if [ ! -z "${FLAGS_oem_pkg}" ] && ! set_vm_oem_pkg "${FLAGS_oem_pkg}"; then
+  die_notrace "Invalid oem : ${FLAGS_oem_pkg}"
 fi
 
 if [ -z "${FLAGS_board}" ] ; then


### PR DESCRIPTION
This option sets the IMG_DEFAULT_OEM_PACKAGE variable to the supplied
string.  If a ':' is present, what follows it gets put in the
IMG_DEFAULT_OEM_USE variable and what precedes in the former.

Now you can do things like:

for fmt in cloudstack \
        digitalocean \
        ec2-compat:ec2 \
        ec2-compat:openstack \
        ec2-compat:brightbox \
        exoscale \
        gce \
        hyperv \
        rackspace \
        rackspace-onmetal; do
    ./image_to_vm.sh --format=qemu --oem_pkg=$fmt
    ../build/images/amd64-usr/latest/coreos_developer_qemu.sh -curses
done

rather than having to modify build_library/vm_image_util.sh to test oem
builds in qemu.
