### PR TITLE
Upgrades virtual hardware version to a more reasonable minimum default

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -603,7 +603,7 @@ _write_vmx_conf() {
 #!/usr/bin/vmware
 .encoding = "UTF-8"
 config.version = "8"
-virtualHW.version = "4"
+virtualHW.version = "7"
 cleanShutdown = "TRUE"
 displayName = "${VM_NAME}"
 ethernet0.addressType = "generated"


### PR DESCRIPTION
Version 4 is too low. Some VMware products even crash trying to upgrade it to a greater version (VMware Fusion 6 Pro). Having at least 7 will allow us to use some modern features in most VMware
products, such as enabling `vmxnet3` virtual network adapters or adding
much more memory and cpu cores to virtual machines.
