### PR TITLE
virtualbox_ovf.sh: use virtio network interfaces

### DIFF
--- a/build_library/virtualbox_ovf.sh
+++ b/build_library/virtualbox_ovf.sh
@@ -178,14 +178,14 @@ if [[ -n "${FLAGS_output_ovf}" ]]; then
         </BIOS>
         <USBController enabled="false" enabledEhci="false"/>
         <Network>
-          <Adapter slot="0" enabled="true" MACAddress="${PRIMARY_MAC}" cable="true" speed="0" type="82540EM">
+          <Adapter slot="0" enabled="true" MACAddress="${PRIMARY_MAC}" cable="true" speed="0" type="virtio">
             <DisabledModes/>
             <NAT>
               <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
               <Alias logging="false" proxy-only="false" use-same-ports="false"/>
             </NAT>
           </Adapter>
-          <Adapter slot="1" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="82540EM">
+          <Adapter slot="1" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="virtio">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -193,7 +193,7 @@ if [[ -n "${FLAGS_output_ovf}" ]]; then
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="2" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="82540EM">
+          <Adapter slot="2" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="virtio">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -201,7 +201,7 @@ if [[ -n "${FLAGS_output_ovf}" ]]; then
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="3" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="82540EM">
+          <Adapter slot="3" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="virtio">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -209,7 +209,7 @@ if [[ -n "${FLAGS_output_ovf}" ]]; then
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="4" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="82540EM">
+          <Adapter slot="4" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="virtio">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -217,7 +217,7 @@ if [[ -n "${FLAGS_output_ovf}" ]]; then
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="5" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="82540EM">
+          <Adapter slot="5" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="virtio">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -225,7 +225,7 @@ if [[ -n "${FLAGS_output_ovf}" ]]; then
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="6" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="82540EM">
+          <Adapter slot="6" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="virtio">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -233,7 +233,7 @@ if [[ -n "${FLAGS_output_ovf}" ]]; then
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="7" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="82540EM">
+          <Adapter slot="7" enabled="false" MACAddress="$(macgen)" cable="true" speed="0" type="virtio">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>


### PR DESCRIPTION
The [**virtio**](https://www.virtualbox.org/manual/ch06.html) paravirtualized adapter is well-supported and more efficient than virtualized NICs in VirtualBox. It is the default for boot2docker, for example, and fixes in [CoreOS 459.0.0](https://github.com/coreos/manifest/releases/tag/v459.0.0) make it reliable to use now.

I exported a CoreOS 490.0.0 VM using virtio from VirtualBox as an .ovf file, compared it to the template, and saw no differences other than the adapter type field, so I believe this is sufficient to default to virtio in virtualbox.

Refs coreos/coreos-vagrant#178.
