### PR TITLE
disk_util: Set priority and successful attributes in new images

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -29,7 +29,8 @@
         "blocks":"2097152",
         "fs_blocks":"262144",
         "fs_type":"ext2",
-        "mount":"/usr"
+        "mount":"/usr",
+        "features": ["prioritize"]
       },
       "4":{
         "label":"USR-B",

--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -278,6 +278,7 @@ def WritePartitionTable(options, config=None, partitions=None):
 
   syslinux = False
   hybrid = None
+  prioritize = []
   for partition in partitions.itervalues():
     if partition['type'] != 'blank':
       Cgpt('add', '-i', partition['num'],
@@ -293,6 +294,8 @@ def WritePartitionTable(options, config=None, partitions=None):
         hybrid = partition['num']
       if 'syslinux' in features:
         syslinux = True
+      if 'prioritize' in features:
+        prioritize.append(partition)
 
   if hybrid:
     # Enable legacy boot flag and generate a hybrid MBR partition table
@@ -313,6 +316,10 @@ def WritePartitionTable(options, config=None, partitions=None):
 
     with open(options.disk_image, 'r+') as image_fd:
       image_fd.write(mbr_code)
+
+  prioritize.reverse()
+  for i, partition in enumerate(prioritize):
+    Cgpt('add', '-i', partition['num'], '-S1', '-P', i+1, options.disk_image)
 
   Cgpt('show', options.disk_image)
 


### PR DESCRIPTION
Mark the initial copy of CoreOS as 'successful' and with a non-zero
priority. Required to boot with a stricter interpretation of the
partition selection scheme which ignores partitions that have a priority
of zero. The new grub implementation follows this rule and is what the
original ChromeOS spec used too.

For the sake of completeness if multiple partitions are configured in
the json file with this feature they will be prioritized in disk-order.
