### PR TITLE
scripts/oem/ami: fix bad array subscript

### DIFF
--- a/oem/ami/copy_ami.sh
+++ b/oem/ami/copy_ami.sh
@@ -33,7 +33,7 @@ GROUP="alpha"
 REGIONS=()
 
 add_region() {
-    if [[ -z "${ALL_REGIONS[$1]}" ]]; then
+    if [[ -z "${ALL_AKIS[$1]}" ]]; then
         echo "Invalid region '$1'" >&2;
         exit 1
     fi


### PR DESCRIPTION
Broken in 8abceaa20e10ff5f3543a54e69b5accddfd5f7b9.
