### PR TITLE
build_library: make sure /etc/mtab is correct before modifying images

### DIFF
--- a/build_image
+++ b/build_image
@@ -149,6 +149,8 @@ users:
 EOF
 fi
 
+fix_mtab
+
 if [[ "${DEV_IMAGE}" -eq 1 ]]; then
   create_dev_image ${COREOS_DEVELOPER_IMAGE_NAME} ${DISK_LAYOUT} ${FLAGS_group}
   if [[ ${FLAGS_extract_update} -eq ${FLAGS_TRUE} ]]; then

--- a/common.sh
+++ b/common.sh
@@ -601,6 +601,13 @@ is_mounted() {
   fi
 }
 
+fix_mtab() {
+    local root="$1" mounts="../proc/self/mounts"
+    if [[ "$(readlink "${root}/etc/mtab")" != "${mounts}" ]]; then
+        sudo ln -sf "${mounts}" "${root}/etc/mtab"
+    fi
+}
+
 get_git_id() {
   git var GIT_COMMITTER_IDENT | sed -e 's/^.*<\(\S\+\)>.*$/\1/'
 }

--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -103,6 +103,8 @@ fi
 # Make sure things are cleaned up on failure
 trap vm_cleanup EXIT
 
+fix_mtab
+
 # Setup new (raw) image, possibly resizing filesystems
 setup_disk_image "${FLAGS_disk_layout}"
 

--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -209,6 +209,8 @@ setup_env() {
       fi
     done
 
+    fix_mtab "${FLAGS_chroot}"
+
     debug "Mounting chroot environment."
     MOUNT_CACHE=$(echo $(awk '{print $2}' /proc/mounts))
 


### PR DESCRIPTION
If mtab ever gets replaced by a regular file all sorts of things break.
