### PR TITLE
grub: use new mount.usr kernel command line args

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -58,18 +58,17 @@ function load_coreos {
     echo "Booting CoreOS!"
 }
 
-# TODO: systemd 217 added mount.usr=, once we update we should switch
 menuentry "CoreOS default" --id=coreos {
     gptprio.next -d root -u usr_uuid
-    load_coreos usr=PARTUUID=$usr_uuid
+    load_coreos mount.usr=PARTUUID=$usr_uuid
 }
 
 menuentry "CoreOS USR-A" --id=coreos-a {
     search --no-floppy --set root --part-label USR-A --hint "$root"
-    load_coreos usr=PARTLABEL=USR-A
+    load_coreos mount.usr=PARTLABEL=USR-A
 }
 
 menuentry "CoreOS USR-B" --id=coreos-b {
     search --no-floppy --set root --part-label USR-B --hint "$root"
-    load_coreos usr=PARTLABEL=USR-B
+    load_coreos mount.usr=PARTLABEL=USR-B
 }


### PR DESCRIPTION
Depends on https://github.com/coreos/coreos-overlay/pull/991
