### PR TITLE
grub: search for OEM by partition label instead of filesystem label

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -17,7 +17,7 @@ set linux_append=""
 
 
 # Search for the OEM partition, load additional configuration if found.
-search --no-floppy --set oem --label OEM --hint "$root"
+search --no-floppy --set oem --part-label OEM --hint "$root"
 if [ -n "$oem" -a -f "($oem)/grub.cfg" ]; then
     source "($oem)/grub.cfg"
 fi


### PR DESCRIPTION
Probing all filesystem types on all block devices appears to hang
booting Amazon EC2 HVM instances. The console output is unreliably
buffered so there is no information on what the failure actually is. On
the up side we can work around it easily by only searching the GPT which
appears to be safe.
