### PR TITLE
setup_board: export paths to kernel source and build directories

### DIFF
--- a/setup_board
+++ b/setup_board
@@ -249,6 +249,10 @@ PORT_LOGDIR="${BOARD_ROOT}/var/log/portage"
 PORTAGE_TMPDIR="${BOARD_ROOT}/var/tmp"
 PORTAGE_BINHOST="${BOARD_BINHOST}"
 
+# Tell the linux-info eclass where it can find our kernel
+KERNEL_DIR="${BOARD_ROOT}/usr/src/linux"
+KBUILD_OUTPUT="${BOARD_ROOT}/var/cache/portage/sys-kernel/coreos-kernel"
+
 # Generally there isn't any need to add packages to @world by default.
 # You can use --select to override this.
 EMERGE_DEFAULT_OPTS="--oneshot"


### PR DESCRIPTION
The linux-info eclass may trigger a fatal error if it is unable to check
a package's required kernel options. Even when the error isn't fatal the
warnings add a lot of clutter to our build output.
