### PR TITLE
bootstrap_sdk: prune extra files from SDK tarballs

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -48,6 +48,8 @@ pkgcache_path: $BINPKGS
 stage4/packages: coreos-devel/sdk-depends
 stage4/fsscript: ${BUILD_LIBRARY_DIR}/catalyst_default_stage4.sh
 stage4/root_overlay: ${TEMPDIR}/stage4_overlay
+stage4/empty: /root /usr/portage /var/cache/edb
+stage4/rm: /etc/machine-id /etc/resolv.conf
 EOF
 catalyst_stage_default
 }


### PR DESCRIPTION
stage1/2/3 tarballs automatically prune things like /usr/portage but
stage4 does not. Add explicit rules to prune extra cruft.
