### PR TITLE
Extra portdir support

### DIFF
--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -159,7 +159,7 @@ init_setup () {
    ln -sf "${CHROOT_TRUNK_DIR}/src/third_party/portage-stable" \
      "${FLAGS_chroot}"/"${PORTAGE_STABLE_OVERLAY}"
 
-   if [[ -n "${FLAGS_extra_portdir_overlay_path }" ]]; then
+   if [[ -n "${FLAGS_extra_portdir_overlay_path}" ]]; then
      if [[ -n "${FLAGS_extra_portdir_overlay_name}" ]]; then
        ln -sf "${CHROOT_TRUNK_DIR}"/"${FLAGS_extra_portdir_overlay_path}" \
          "${FLAGS_chroot}"/usr/local/portage/"${FLAGS_extra_portdir_overlay_name}"

--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -47,6 +47,11 @@ DEFINE_string stage3_path "" \
   "Use the stage3 located on this path."
 DEFINE_string cache_dir "" "Directory to store caches within."
 
+DEFINE_string extra_portdir_overlay_path "" \
+  "Extra PORTDIR_OVERLAY direcory path outside of the chroot."
+DEFINE_string extra_portdir_overlay_name "" \
+  "Name of the symlink directory that will be created inside the chroot."
+
 # Parse command line flags.
 FLAGS_HELP="usage: $SCRIPT_NAME [flags]"
 FLAGS "$@" || exit 1
@@ -153,6 +158,13 @@ init_setup () {
      "${FLAGS_chroot}"/"${CHROOT_OVERLAY}"
    ln -sf "${CHROOT_TRUNK_DIR}/src/third_party/portage-stable" \
      "${FLAGS_chroot}"/"${PORTAGE_STABLE_OVERLAY}"
+
+   if [[ -n "${FLAGS_extra_portdir_overlay_path }" ]]; then
+     if [[ -n "${FLAGS_extra_portdir_overlay_name}" ]]; then
+       ln -sf "${CHROOT_TRUNK_DIR}"/"${FLAGS_extra_portdir_overlay_path}" \
+         "${FLAGS_chroot}"/usr/local/portage/"${FLAGS_extra_portdir_overlay_name}"
+     fi
+   fi
 
    # Set up sudoers.  Inside the chroot, the user can sudo without a password.
    # (Safe enough, since the only way into the chroot is to 'sudo chroot', so
@@ -317,6 +329,11 @@ else
 fi
 if [[ "${FLAGS_jobs}" -ne -1 ]]; then
   UPDATE_ARGS+=( --jobs=${FLAGS_jobs} )
+fi
+if [[ -n "${FLAGS_extra_portdir_overlay_path }" ]]; then
+  if [[ -n "${FLAGS_extra_portdir_overlay_name}" ]]; then
+    UPDATE_ARGS+=( "--extra_portdir_overlay_dir=/usr/local/portage/${FLAGS_extra_portdir_overlay_name}" )
+  fi
 fi
 enter_chroot "${CHROOT_TRUNK_DIR}/src/scripts/update_chroot" "${UPDATE_ARGS[@]}"
 

--- a/sdk_lib/make_chroot.sh
+++ b/sdk_lib/make_chroot.sh
@@ -330,7 +330,7 @@ fi
 if [[ "${FLAGS_jobs}" -ne -1 ]]; then
   UPDATE_ARGS+=( --jobs=${FLAGS_jobs} )
 fi
-if [[ -n "${FLAGS_extra_portdir_overlay_path }" ]]; then
+if [[ -n "${FLAGS_extra_portdir_overlay_path}" ]]; then
   if [[ -n "${FLAGS_extra_portdir_overlay_name}" ]]; then
     UPDATE_ARGS+=( "--extra_portdir_overlay_dir=/usr/local/portage/${FLAGS_extra_portdir_overlay_name}" )
   fi

--- a/update_chroot
+++ b/update_chroot
@@ -35,6 +35,9 @@ DEFINE_boolean skip_toolchain_update $FLAGS_FALSE \
 DEFINE_string toolchain_boards "" \
   "Extra toolchains to setup for the specified boards."
 
+DEFINE_string extra_portdir_overlay_dir "" \
+  "Extra directory path to be added to PORTDIR_OVERLAY."
+
 # Parse command line flags
 FLAGS "$@" || exit 1
 eval set -- "${FLAGS_ARGV}"
@@ -49,6 +52,11 @@ PORTAGE_STABLE_OVERLAY="/usr/local/portage/stable"
 CROSSDEV_OVERLAY="/usr/local/portage/crossdev"
 COREOS_OVERLAY="/usr/local/portage/coreos"
 COREOS_CONFIG="${COREOS_OVERLAY}/coreos/config"
+if [[ -n "${FLAGS_extra_portdir_overlay_dir}" ]]; then
+  EXTRA_PORTDIR_OVERLAY="${FLAGS_extra_portdir_overlay_dir}"
+else
+  EXTRA_PORTDIR_OVERLAY=""
+fi
 
 info "Setting up portage..."
 sudo mkdir -p "/etc/portage/repos.conf/"
@@ -58,7 +66,7 @@ sudo touch "/etc/portage/make.conf.user"
 sudo_clobber "/etc/portage/make.conf" <<EOF
 # Created by update_chroot
 PORTDIR="${PORTAGE_STABLE_OVERLAY}"
-PORTDIR_OVERLAY="${CROSSDEV_OVERLAY} ${COREOS_OVERLAY}"
+PORTDIR_OVERLAY="${CROSSDEV_OVERLAY} ${COREOS_OVERLAY} ${EXTRA_PORTDIR_OVERLAY}"
 DISTDIR="/var/lib/portage/distfiles"
 PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"


### PR DESCRIPTION
Adding the ability to specify an extra portdir_overlay directory into a CoreOS build. This will be useful functionality for all the people who want to build otherwise vanilla CoreOS images, but with additional software for whatever they are trying to do. There is an associated pull request on the chromite repo. coreos/chromite#18