### PR TITLE
catalyst: disable ccache and autoresume

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -58,7 +58,7 @@ cat <<EOF
 contents="auto"
 digests="md5 sha1 sha512 whirlpool"
 hash_function="crc32"
-options="autoresume ccache pkgcache"
+options="pkgcache"
 sharedir="/usr/lib/catalyst"
 storedir="$CATALYST_ROOT"
 distdir="$DISTDIR"


### PR DESCRIPTION
Disable ccache as it is causing issues in other builds so disable it
everywhere to be safe. Disable the autoresume feature because our build
process doesn't actually make use of it.