### PR TITLE
toolchain_util: fix parsing emerge --pretend output

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -181,7 +181,7 @@ _get_dependency_list() {
 
     PORTAGE_CONFIGROOT="$ROOT" emerge "$@" --pretend \
         --emptytree --root-deps=rdeps --onlydeps --quiet | \
-        sed -e 's/.*\] \([^ :]*\).*/=\1/' |
+        sed -e 's/[^]]*\] \([^ :]*\).*/=\1/' |
         egrep -v "(=$(echo "${pkgs[*]}")-[0-9])"
 }
 


### PR DESCRIPTION
Fix parsing the following output:

    [ebuild  N    ] dev-libs/gmp-5.1.3-r1 to /usr/x86_64-cros-linux-gnu/
    [ebuild     UD] sys-libs/timezone-data-2013d [2014i-r1] to /usr/x86_64-cros-linux-gnu/

The previous regex did not account for upgrades and got confused by the
`[2014i-r1]` listing and goobbled up too much of the string. I am not
sure *why* portage is reporting an upgrade when --emptytree is also used
but there it is. Match all not-] characters instead.