### PR TITLE
Enhanced dev_image_util with equivalent to --base_pkg

### DIFF
--- a/build_image
+++ b/build_image
@@ -26,6 +26,8 @@ DEFINE_boolean enable_rootfs_verification ${FLAGS_TRUE} \
   "Default all bootloaders to use kernel-based root fs integrity checking."
 DEFINE_string base_pkg "coreos-base/coreos" \
   "The base portage package to base the build off of (only applies to prod images)"
+DEFINE_string base_dev_pkg "coreos-base/coreos-dev" \
+  "The base portage package to base the build off of (only applies to dev images)"
 DEFINE_string output_root "${DEFAULT_BUILD_ROOT}/images" \
   "Directory in which to place image result directories (named by version)"
 DEFINE_string disk_layout "" \
@@ -152,14 +154,14 @@ fi
 fix_mtab
 
 if [[ "${DEV_IMAGE}" -eq 1 ]]; then
-  create_dev_image ${COREOS_DEVELOPER_IMAGE_NAME} ${DISK_LAYOUT} ${FLAGS_group}
+  create_dev_image ${COREOS_DEVELOPER_IMAGE_NAME} ${DISK_LAYOUT} ${FLAGS_group} ${FLAGS_base_dev_pkg}
   if [[ ${FLAGS_extract_update} -eq ${FLAGS_TRUE} ]]; then
     extract_update "${COREOS_DEVELOPER_IMAGE_NAME}" "${DISK_LAYOUT}"
   fi
 fi
 
 if [[ "${CONTAINER}" -eq 1 ]]; then
-  create_dev_image "${COREOS_DEVELOPER_CONTAINER_NAME}" "${CONTAINER_LAYOUT}" "${FLAGS_group}"
+  create_dev_image "${COREOS_DEVELOPER_CONTAINER_NAME}" "${CONTAINER_LAYOUT}" "${FLAGS_group}" ${FLAGS_base_dev_pkg}
 fi
 
 if [[ "${PROD_IMAGE}" -eq 1 ]]; then

--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -70,8 +70,14 @@ create_dev_image() {
   local image_name=$1
   local disk_layout=$2
   local update_group=$3
+  local base_pkg="$4"
   local devserver=$(detect_dev_url)
   local auserver=""
+
+  if [ -z "${base_pkg}" ]; then
+    echo "did not get base package!"
+    exit 1
+  fi
 
   if [[ -n "${devserver}" ]]; then
     info "Using ${devserver} for local dev server URL."
@@ -88,7 +94,7 @@ create_dev_image() {
   start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 
   set_image_profile dev
-  emerge_to_image "${root_fs_dir}" @system coreos-base/coreos-dev
+  emerge_to_image "${root_fs_dir}" @system ${base_pkg}
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
 
   # Setup portage for emerge and gmerge


### PR DESCRIPTION
- "./build_image prod" already has the ability to specify which package will specify all the packages that should be pulled in and built into an image by specifying a package name using the --base_pkg command line flag. This creates an equivalent option for "./build_image dev" creating a --base_dev_pkg flag that passes a package name into the create_dev_img() function in dev_image_util.sh the same way that --base_pkg is passed into create_prod_image() inside prod_image_util.sh.