### PR TITLE
build_image_util: generate package license list for each image

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -84,12 +84,14 @@ create_dev_image() {
   local root_fs_dir="${BUILD_DIR}/rootfs"
   local image_contents="${image_name%.bin}_contents.txt"
   local image_packages="${image_name%.bin}_packages.txt"
+  local image_licenses="${image_name%.bin}_licenses.txt"
 
   start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 
   set_image_profile dev
   emerge_to_image "${root_fs_dir}" @system coreos-base/coreos-dev
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
+  write_licenses "${root_fs_dir}" "${BUILD_DIR}/${image_licenses}"
 
   # Setup portage for emerge and gmerge
   configure_dev_portage "${root_fs_dir}" "${devserver}"

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -39,6 +39,7 @@ create_prod_image() {
   local root_fs_dir="${BUILD_DIR}/rootfs"
   local image_contents="${image_name%.bin}_contents.txt"
   local image_packages="${image_name%.bin}_packages.txt"
+  local image_licenses="${image_name%.bin}_licenses.txt"
 
   start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 
@@ -47,6 +48,7 @@ create_prod_image() {
   extract_prod_gcc "${root_fs_dir}"
   emerge_to_image "${root_fs_dir}" "${base_pkg}"
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
+  write_licenses "${root_fs_dir}" "${BUILD_DIR}/${image_licenses}"
   extract_docs "${root_fs_dir}"
 
   # Assert that if this is supposed to be an official build that the


### PR DESCRIPTION
There isn't a sane way for users to know the licenses of individual
packages in CoreOS images in built images. The information is hidden
away back in the original ebuilds. This extends our existing package
list with a new file that also includes licenses:

```
app-admin/flannel-0.3.0-r3::coreos Apache-2.0
app-admin/fleet-0.9.1::coreos Apache-2.0
app-admin/locksmith-0.2.3::coreos Apache-2.0
app-admin/sdnotify-proxy-0.1.0::coreos Apache-2.0
app-admin/sudo-1.8.10_p2::portage-stable ISC BSD
app-admin/toolbox-0.0.0-r4::coreos Apache-2.0
app-arch/bzip2-1.0.6-r6::portage-stable BZIP2
app-arch/gzip-1.5::portage-stable GPL-3
app-arch/tar-1.27.1-r2::portage-stable GPL-3+
...
```