### PR TITLE
disk_util: include fsck output during resize operation

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -508,7 +508,7 @@ def ResizeExt(part, device):
     part: dict defining the partition
     device: name of the block device
   """
-  Sudo(['e2fsck', '-p', '-f', device], stdout_null=True)
+  Sudo(['e2fsck', '-p', '-f', device])
   Sudo(['resize2fs', device, str(part['fs_blocks'])])
 
 


### PR DESCRIPTION
Previously fsck output was suppressed to reduce the amount of noise in
build logs on the assumption that fsck really shouldn't have a reason to
fail. The filesystem is freshly created after all. However some users
have reported that fsck is failing but without error messages we don't
know why.