### PR TITLE
oem/ami: update tests for etcd2

### DIFF
--- a/oem/ami/test_ami.sh
+++ b/oem/ami/test_ami.sh
@@ -156,6 +156,9 @@ for host in ${ips[@]}; do
 done
 echo "OK ($instances)"
 
+echo "Letting etcd settle..."
+sleep 10
+
 echo "Running coretest..."
 for host in ${ips[@]}; do
     if ! ssh -i "$key_file" -l core -o StrictHostKeyChecking=no "$host" \
@@ -168,7 +171,7 @@ done
 echo "OK"
 
 echo -n "Testing etcd... "
-test_key="v1/keys/test"
+test_key="v2/keys/test"
 token=$(uuidgen)
 # XXX: the sleep *should never* be required, this is a bug in etcd
 sleep 5


### PR DESCRIPTION
The v1 API has been removed, so use v2 instead. The 10-second sleep was
added because the fleet tests were failing without it. My guess is that
etcd needed some time to warm up before we flooded it with requests.