### PR TITLE
catalyst: hacky fix for amd64 toolchain builds

### DIFF
--- a/build_library/catalyst_toolchains.sh
+++ b/build_library/catalyst_toolchains.sh
@@ -34,6 +34,16 @@ build_target_toolchain() {
 mkdir -p "/tmp/crossdev"
 export PORTDIR_OVERLAY="/tmp/crossdev $(portageq envvar PORTDIR_OVERLAY)"
 
+# For some reason the final native native toolchain build is doing a two
+# stage gcc build despite CBUILD!=CHOST when I would have assumed it is
+# disabled. In the process xgcc/cc1 gets linked against the wrong libs,
+# sysroot isn't properly respected, and so forth. To at least get amd64
+# builds working again make double sure the build environment is updated
+# to reduce the risk of mismatched library versions. I haven't checked if
+# the two stage build kicks in for true cross-architecture builds yet.
+# This is the same update command as stage1 catalyst uses.
+run_merge --update --deep --newuse --complete-graph --rebuild-if-new-ver sys-devel/gcc
+
 for cross_chost in $(get_chost_list); do
     echo "Building cross toolchain for ${cross_chost}"
     PKGDIR="$(portageq envvar PKGDIR)/crossdev" \


### PR DESCRIPTION
The mpc upgrade is breaking the board toolchain build because the
two-stage build process is improperly kicking in, the wrong libraries
get linked, sysroot ignored, and other unpleasentries.

This should work around the issue pending fixing the gcc ebuild or
whatever is allowing the two-stage build to kick in for cross-compiled
builds.