### PR TITLE
Fixes for cross compiling

### DIFF
--- a/build_library/catalyst_toolchains.sh
+++ b/build_library/catalyst_toolchains.sh
@@ -16,7 +16,8 @@ configure_target_root() {
     local cross_chost=$(get_board_chost "$1")
     local profile=$(get_board_profile "${board}")
 
-    CHOST="${cross_chost}" \
+    CBUILD="$(portageq envvar CBUILD)" \
+        CHOST="${cross_chost}" \
         ROOT="/build/${board}" \
         SYSROOT="/usr/${cross_chost}" \
         _configure_sysroot "${profile}"

--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -187,7 +187,8 @@ _get_dependency_list() {
 
 # Configure a new ROOT
 # Values are copied from the environment or the current host configuration.
-# Usage: ROOT=/foo/bar SYSROOT=/foo/bar configure_portage coreos:some/profile
+# Usage: CBUILD=foo-bar-linux-gnu ROOT=/foo/bar SYSROOT=/foo/bar configure_portage coreos:some/profile
+# Note: if using portageq to get CBUILD it must be called before CHOST is set.
 _configure_sysroot() {
     local profile="$1"
 
@@ -279,7 +280,10 @@ install_cross_libs() {
         sudo="sudo -E"
     fi
 
-    CHOST="${cross_chost}" ROOT="$ROOT" SYSROOT="$ROOT" \
+    CBUILD="$(portageq envvar CBUILD)" \
+        CHOST="${cross_chost}" \
+        ROOT="$ROOT" \
+        SYSROOT="$ROOT" \
         _configure_sysroot "${CROSS_PROFILES[${cross_chost}]}"
 
     # In order to get a dependency list we must calculate it before

--- a/setup_board
+++ b/setup_board
@@ -265,7 +265,7 @@ sudo cp /etc/portage/repos.conf/* "${BOARD_ETC}"/portage/repos.conf/
 
 # make it easy to find debug symbols
 sudo mkdir -p /usr/lib/debug/build
-sudo ln -sfT /build/amd64-usr/usr/lib/debug /usr/lib/debug/build/amd64-usr
+sudo ln -sfT ${BOARD_ROOT}/usr/lib/debug /usr/lib/debug/${BOARD_ROOT}
 
 generate_all_wrappers
 


### PR DESCRIPTION
Replaces https://github.com/coreos/scripts/pull/388, pruning down the diff a little.

In addition to (hopefully) fixing true cross-architecture builds this resolves an issue caused by the recent mpc upgrade. Since without this CHOST==CBUILD cross-compiling logic wasn't properly engaged and the two-phase gcc build kicked in, linking against some things under `/build/$BOARD` but then failing to run because the host chroot had a different mpc library.