### PR TITLE
toolchain_util: include repos.conf in bootstrap build environments

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -80,11 +80,28 @@ export PORTAGE_GRPNAME=portage
 EOF
 }
 
+repos_conf() {
+cat <<EOF
+[DEFAULT]
+main-repo = portage-stable
+
+[gentoo]
+disabled = true
+
+[coreos]
+location = /usr/portage
+
+[portage-stable]
+location = /usr/local/portage
+EOF
+}
+
 # Common values for all stage spec files
 catalyst_stage_default() {
 cat <<EOF
 subarch: $ARCH
 rel_type: $TYPE
+portage_confdir: $TEMPDIR/portage
 portage_overlay: $FLAGS_coreos_overlay
 profile: $FLAGS_profile
 snapshot: $FLAGS_version
@@ -212,20 +229,22 @@ write_configs() {
     export CCACHE_DIR="$TEMPDIR/ccache"
 
     info "Creating output directories..."
-    mkdir -m 775 -p "$TEMPDIR" "$DISTDIR" "$CCACHE_DIR"
+    mkdir -m 775 -p "$TEMPDIR/portage/repos.conf" "$DISTDIR" "$CCACHE_DIR"
     chown portage:portage "$DISTDIR" "$CCACHE_DIR"
     info "Writing out catalyst configs..."
-    info "    $TEMPDIR/catalyst.conf"
+    info "    catalyst.conf"
     catalyst_conf > "$TEMPDIR/catalyst.conf"
-    info "    $TEMPDIR/catalystrc"
+    info "    catalystrc"
     catalystrc > "$TEMPDIR/catalystrc"
-    info "    $TEMPDIR/stage1.spec"
+    info "    portage/repos.conf/coreos.conf"
+    repos_conf > "$TEMPDIR/portage/repos.conf/coreos.conf"
+    info "    stage1.spec"
     catalyst_stage1 > "$TEMPDIR/stage1.spec"
-    info "    $TEMPDIR/stage2.spec"
+    info "    stage2.spec"
     catalyst_stage2 > "$TEMPDIR/stage2.spec"
-    info "    $TEMPDIR/stage3.spec"
+    info "    stage3.spec"
     catalyst_stage3 > "$TEMPDIR/stage3.spec"
-    info "    $TEMPDIR/stage4.spec"
+    info "    stage4.spec"
     catalyst_stage4 > "$TEMPDIR/stage4.spec"
 }
 

--- a/build_library/catalyst_toolchains.sh
+++ b/build_library/catalyst_toolchains.sh
@@ -32,8 +32,7 @@ build_target_toolchain() {
         run_merge -u --root="$ROOT" "${TOOLCHAIN_PKGS[@]}"
 }
 
-mkdir -p "/tmp/crossdev"
-export PORTDIR_OVERLAY="/tmp/crossdev $(portageq envvar PORTDIR_OVERLAY)"
+configure_crossdev_overlay / /tmp/crossdev
 
 for cross_chost in $(get_chost_list); do
     echo "Building cross toolchain for ${cross_chost}"

--- a/update_chroot
+++ b/update_chroot
@@ -125,16 +125,7 @@ sudo eselect profile set --force "$(get_sdk_profile)"
 
 # Create crossdev repo_name and metadata
 info "Setting up crossdev..."
-sudo mkdir -p "${FLAGS_chroot}/${CROSSDEV_OVERLAY}/profiles"
-echo "x-crossdev" | \
-    sudo tee "/${CROSSDEV_OVERLAY}/profiles/repo_name" > /dev/null
-
-sudo mkdir -p "/${CROSSDEV_OVERLAY}/metadata"
-sudo tee "/${CROSSDEV_OVERLAY}/metadata/layout.conf" > /dev/null <<EOF
-masters = portage-stable coreos
-use-manifests = true
-thin-manifests = true
-EOF
+configure_crossdev_overlay "${FLAGS_chroot}" "${CROSSDEV_OVERLAY}"
 
 # Run version hooks as pre-update
 if [[ -f /etc/os-release ]]; then


### PR DESCRIPTION
This is required for the eventual removal of `$PORTDIR` and
`$PORTDIR_OVERLAY` and ensures toolchain rebuilds/updates with
`./build_packages --nousepkg` don't erroniously try to use ebuilds from
`/usr/portage` inside of the SDK.

In order to fix up the build_toolchains script the crossdev overlay
needs to be setup properly, previously only setup_board did it.

Overall silences a lot of warnings and fixes an issue with crossdev:

    /usr/bin/emerge-wrapper: line 48: /eclass/toolchain-funcs.eclass: No such file or directory
    /usr/bin/emerge-wrapper: line 49: tc-arch: command not found