### PR TITLE
Add support for Secure Boot images and sign unofficial builds with test ...

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -141,8 +141,17 @@ case "${FLAGS_target}" in
     x86_64-efi)
         info "Installing default x86_64 UEFI bootloader."
         sudo mkdir -p "${ESP_DIR}/EFI/boot"
-        sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
-            "${ESP_DIR}/EFI/boot/bootx64.efi"
+	# Use the test keys for signing unofficial builds
+	if [[ ${COREOS_OFFICIAL:-0} -ne 1 ]]; then
+            sudo sbsign --key /usr/share/sb_keys/DB.key \
+		--cert /usr/share/sb_keys/DB.crt \
+                    "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}"
+            sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}.signed" \
+                "${ESP_DIR}/EFI/boot/bootx64.efi"
+        else
+            sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
+                "${ESP_DIR}/EFI/boot/bootx64.efi"
+	fi
         ;;
     x86_64-xen)
         info "Installing default x86_64 Xen bootloader."


### PR DESCRIPTION
...keys

Add qemu_uefi_secure target for building Secure Boot images. These are
identical to qemu_uefi images with the exception that the test keys have
been installed into the flash image, enabling Secure Boot by default. In
addition, sign the grub binary with the test keys during build when producing
unofficial images.