### PR TITLE
Add support for signed kernels

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -1,5 +1,8 @@
 # Main GRUB config
 
+# Set the prefix back to the correct value after we're done with memdisk
+set prefix=($root)/coreos/grub
+
 # Load any and all video drivers.
 # Required under UEFI to boot Linux with a working console.
 insmod all_video
@@ -37,38 +40,30 @@ if [ -z "$linux_console" ]; then
     fi
 fi
 
-
-# Load a kernel and boot! $root must point at USR-A or USR-B
-function load_coreos {
-    # UEFI uses linuxefi/initrdefi instead of linux/initrd
-    if [ "$grub_platform" = efi ]; then
-        set suf="efi"
-    else
-        set suf=""
-    fi
-
-    echo "Loading ($root)/boot/vmlinuz"
-    linux$suf /boot/vmlinuz $linux_console $linux_root "$@" $linux_append
-
-    if [ -f /boot/initrd ]; then
-        echo "Loading ($root)/boot/initrd"
-        initrd$suf /boot/initrd
-    fi
-
-    echo "Booting CoreOS!"
-}
+# UEFI uses linuxefi/initrdefi instead of linux/initrd
+if [ "$grub_platform" = efi ]; then
+    set suf="efi"
+else
+    set suf=""
+fi
 
 menuentry "CoreOS default" --id=coreos {
-    gptprio.next -d root -u usr_uuid
-    load_coreos mount.usr=PARTUUID=$usr_uuid
+    gptprio.next -d usr -u usr_uuid
+    if [ "$usr_uuid" = "7130c94a-213a-4e5a-8e26-6cce9662f132" ]; then
+       linux$suf /coreos/vmlinuz-a $linux_console $linux_root \
+            mount.usr=PARTUUID=$usr_uuid $linux_append
+    else
+       linux$suf /coreos/vmlinuz-b $linux_console $linux_root \
+            mount.usr=PARTUUID=$usr_uuid $linux_append
+    fi
 }
 
 menuentry "CoreOS USR-A" --id=coreos-a {
-    search --no-floppy --set root --part-label USR-A --hint "$root"
-    load_coreos mount.usr=PARTLABEL=USR-A
+    linux$suf /coreos/vmlinuz-a $linux_console $linux_root \
+         mount.usr=PARTLABEL=USR-A $linux_append
 }
 
 menuentry "CoreOS USR-B" --id=coreos-b {
-    search --no-floppy --set root --part-label USR-B --hint "$root"
-    load_coreos mount.usr=PARTLABEL=USR-B
+    linux$suf /coreos/vmlinuz-b $linux_console $linux_root \
+         mount.usr=PARTLABEL=USR-B $linux_append
 }

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -29,18 +29,19 @@ switch_to_strict_mode
 # Our GRUB lives under coreos/grub so new pygrub versions cannot find grub.cfg
 GRUB_DIR="coreos/grub/${FLAGS_target}"
 
-# Modules required to find and read everything else from ESP
-CORE_MODULES=( fat part_gpt search_fs_uuid gzio )
+# Modules required to boot a standard CoreOS configuration
+CORE_MODULES=( normal search test fat part_gpt search_fs_uuid gzio search_part_label terminal gptprio configfile memdisk tar echo )
 
 # Name of the core image, depends on target
 CORE_NAME=
 
 case "${FLAGS_target}" in
     i386-pc)
-        CORE_MODULES+=( biosdisk )
+        CORE_MODULES+=( biosdisk serial )
         CORE_NAME="core.img"
         ;;
     x86_64-efi)
+	CORE_MODULES+=( serial linuxefi efi_gop )
         CORE_NAME="core.efi"
         ;;
     x86_64-xen)
@@ -111,9 +112,15 @@ info "Generating ${GRUB_DIR}/load.cfg"
 ESP_FSID=$(sudo grub-probe -t fs_uuid -d "${LOOP_DEV}p1")
 sudo_clobber "${ESP_DIR}/${GRUB_DIR}/load.cfg" <<EOF
 search.fs_uuid ${ESP_FSID} root \$root
-set prefix=(\$root)/coreos/grub
+set prefix=(memdisk)
 set
 EOF
+
+if [[ ! -f "${ESP_DIR}/coreos/grub/grub.cfg.tar" ]]; then
+    info "Generating grub.cfg memdisk"
+    sudo tar cf "${ESP_DIR}/coreos/grub/grub.cfg.tar" \
+	 -C "${BUILD_LIBRARY_DIR}" "grub.cfg"
+fi
 
 info "Generating ${GRUB_DIR}/${CORE_NAME}"
 sudo grub-mkimage \
@@ -121,14 +128,9 @@ sudo grub-mkimage \
     --format "${FLAGS_target}" \
     --prefix "(,gpt1)/coreos/grub" \
     --config "${ESP_DIR}/${GRUB_DIR}/load.cfg" \
+    --memdisk "${ESP_DIR}/coreos/grub/grub.cfg.tar" \
     --output "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
     "${CORE_MODULES[@]}"
-
-# This script will get called a few times, no need to re-copy grub.cfg
-if [[ ! -f "${ESP_DIR}/coreos/grub/grub.cfg" ]]; then
-    info "Installing grub.cfg"
-    sudo cp "${BUILD_LIBRARY_DIR}/grub.cfg" "${ESP_DIR}/coreos/grub/grub.cfg"
-fi
 
 # Now target specific steps to make the system bootable
 case "${FLAGS_target}" in

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -147,7 +147,11 @@ case "${FLAGS_target}" in
 		--cert /usr/share/sb_keys/DB.crt \
                     "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}"
             sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}.signed" \
-                "${ESP_DIR}/EFI/boot/bootx64.efi"
+                "${ESP_DIR}/EFI/boot/grub.efi"
+            sudo sbsign --key /usr/share/sb_keys/DB.key \
+                 --cert /usr/share/sb_keys/DB.crt \
+                 --output "${ESP_DIR}/EFI/boot/bootx64.efi" \
+                 "/usr/lib/shim/shim.efi"
         else
             sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
                 "${ESP_DIR}/EFI/boot/bootx64.efi"


### PR DESCRIPTION
grub needs shim in order to verify kernels, and we need to rework our image format a little to enable the dm-verity work. This gets us to a fully trusted boot chain in the qemu-uefi-secure target.