### PR TITLE
oem/ami: update path to ami scripts directory

### DIFF
--- a/oem/ami/master.sh
+++ b/oem/ami/master.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DIR=/home/ec2-user/scripts
+DIR=/home/ec2-user/scripts/oem/ami
 URL="https://commondatastorage.googleapis.com/storage.core-os.net/coreos/amd64-usr/master"
 
 set -e

--- a/oem/ami/prod-publish.sh
+++ b/oem/ami/prod-publish.sh
@@ -3,7 +3,7 @@
 BOARD="amd64-usr"
 GROUP="$1"
 VER="$2"
-DIR=/home/ec2-user/scripts
+DIR=/home/ec2-user/scripts/oem/ami
 
 if [ -z "$GROUP" -o -z "$VER" ]; then
   echo "Usage: $0 alpha 1.2.3" >&2

--- a/oem/ami/prod.sh
+++ b/oem/ami/prod.sh
@@ -3,7 +3,7 @@
 BOARD="amd64-usr"
 GROUP="$1"
 VER="$2"
-DIR=/home/ec2-user/scripts
+DIR=/home/ec2-user/scripts/oem/ami
 
 if [ -z "$GROUP" -o -z "$VER" ]; then
   echo "Usage: $0 alpha 1.2.3" >&2

--- a/oem/ami/user.sh
+++ b/oem/ami/user.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DIR=/home/ec2-user/scripts
+DIR=/home/ec2-user/scripts/oem/ami
 USER=someone
 TYPE=production
 VERSION="367.0.0+2014-07-10-1613"


### PR DESCRIPTION
The ami builder host now has a proper checkout of the scripts repo.