### PR TITLE
oem/ami: add support for publishing AMIs in us-gov-west-1

### DIFF
--- a/oem/ami/copy_ami.sh
+++ b/oem/ami/copy_ami.sh
@@ -71,7 +71,7 @@ fi
 zoneurl=http://instance-data/latest/meta-data/placement/availability-zone
 zone=$(curl --fail -s $zoneurl)
 region=$(echo $zone | sed 's/.$//')
-export EC2_URL="http://ec2.${region}.amazonaws.com"
+export EC2_URL="https://ec2.${region}.amazonaws.com"
 
 if [[ -z "$AMI" ]]; then
     search_name=$(clean_version "CoreOS-$GROUP-$VER")
@@ -96,7 +96,7 @@ else
 fi
 
 if [[ ${#REGIONS[@]} -eq 0 ]]; then
-    REGIONS=( "${ALL_REGIONS[@]}" )
+    REGIONS=( "${MAIN_REGIONS[@]}" )
 fi
 
 # The name has a limited set of allowed characterrs

--- a/oem/ami/import.sh
+++ b/oem/ami/import.sh
@@ -118,7 +118,7 @@ if [ -z "$akiid" ]; then
    exit 1
 fi
 
-export EC2_URL="http://ec2.${region}.amazonaws.com"
+export EC2_URL="https://ec2.${region}.amazonaws.com"
 echo "Building AMI in zone ${EC2_IMPORT_ZONE}"
 
 tmpimg=$(mktemp)

--- a/oem/ami/prod-publish.sh
+++ b/oem/ami/prod-publish.sh
@@ -10,6 +10,4 @@ if [ -z "$GROUP" -o -z "$VER" ]; then
   exit 1
 fi
 
-set -e
-source $DIR/marineam-auth.sh
 $DIR/publish_ami.sh -b $BOARD -g $GROUP -V $VER

--- a/oem/ami/prod.sh
+++ b/oem/ami/prod.sh
@@ -16,3 +16,6 @@ args="-b $BOARD -g $GROUP -V $VER"
 $DIR/import.sh ${args}
 $DIR/test_ami.sh -v ${args}
 $DIR/copy_ami.sh ${args}
+
+source $DIR/ami-builder-us-gov-auth.sh
+$DIR/import.sh ${args}

--- a/oem/ami/regions.sh
+++ b/oem/ami/regions.sh
@@ -13,4 +13,9 @@ ALL_AKIS["ap-southeast-2"]=aki-c362fff9
 ALL_AKIS["ap-northeast-1"]=aki-176bf516
 ALL_AKIS["sa-east-1"]=aki-5553f448
 
+MAIN_REGIONS=( "${!ALL_AKIS[@]}" )
+
+# The following are isolated regions
+ALL_AKIS["us-gov-west-1"]=aki-1de98d3e
+
 ALL_REGIONS=( "${!ALL_AKIS[@]}" )

--- a/oem/ami/test_ami.sh
+++ b/oem/ami/test_ami.sh
@@ -54,7 +54,7 @@ fi
 zoneurl=http://instance-data/latest/meta-data/placement/availability-zone
 zone=$(curl --fail -s $zoneurl)
 region=$(echo $zone | sed 's/.$//')
-export EC2_URL="http://ec2.${region}.amazonaws.com"
+export EC2_URL="https://ec2.${region}.amazonaws.com"
 
 if [[ -z "$AMI" && -n "$VER" ]]; then
     search_name=$(clean_version "CoreOS-$GROUP-$VER")


### PR DESCRIPTION
A few general changes:
 - Use https for EC2 endpoint URLs
 - Remove parallelism from prod-publish, was launching enough Java
   processes at once to trigger OOM :(
 - Only share snapshots with Amazon in us-east-1: only needed for
   marketplace listing and marketplace only uses us-east-1.