### PR TITLE
Don't read OEM config data if Secure Boot is enabled

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -18,11 +18,22 @@ set linux_console=""
 # Anything else the OEM adds should use this variable.
 set linux_append=""
 
+set secure_boot="0"
+
+if [ "$grub_platform" = "efi" ]; then
+   getenv -e SecureBoot -g 8be4df61-93ca-11d2-aa0d-00e098032b8c -b sb
+   getenv -e SetupMode -g 8be4df61-93ca-11d2-aa0d-00e098032b8c -b setupmode
+   if [ "$sb" = "01" -a "$setupmode" = "00" ]; then
+      set secure_boot="1"
+   fi
+fi
 
 # Search for the OEM partition, load additional configuration if found.
-search --no-floppy --set oem --part-label OEM --hint "$root"
-if [ -n "$oem" -a -f "($oem)/grub.cfg" ]; then
-    source "($oem)/grub.cfg"
+if [ "$secure_boot" = "0" ]; then
+   search --no-floppy --set oem --part-label OEM --hint "$root"
+   if [ -n "$oem" -a -f "($oem)/grub.cfg" ]; then
+       source "($oem)/grub.cfg"
+   fi
 fi
 
 # If no specific console has been set by the OEM then select based on

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -41,7 +41,7 @@ case "${FLAGS_target}" in
         CORE_NAME="core.img"
         ;;
     x86_64-efi)
-	CORE_MODULES+=( serial linuxefi efi_gop )
+	CORE_MODULES+=( serial linuxefi efi_gop getenv )
         CORE_NAME="core.efi"
         ;;
     x86_64-xen)


### PR DESCRIPTION
We don't want untrusted configuration to be read if we're in Secure Boot
mode, so skip the OEM config when Secure Boot is enabled and in User Mode.