### PR TITLE
disk_util: add support for experimental nspawn booting

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -76,6 +76,13 @@
         "blocks":"12943360"
       }
     },
+    "nspawn":{
+      "9":{
+        "label":"ROOT",
+        "type":"4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
+        "blocks":"12943360"
+      }
+    },
     "azure":{
       "9":{
         "label":"ROOT",

--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -678,6 +678,12 @@ def Tune2fsReadWrite(options, partition, disable_rw):
     image.seek(partition['first_byte'] + flag_offset)
     image.write(chr(flag_value))
 
+  # bit 60 is 'read-only', TODO: support this in cgpt
+  # http://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
+  attr_cmd = "set" if disable_rw else "clear"
+  attr_arg = "--attributes=%s:%s:60" % (partition['num'], attr_cmd)
+  subprocess.check_call(['sgdisk', attr_arg, options.disk_image])
+
 
 def IsE2fsReadWrite(options, partition):
   """Returns True if FS is read-write, False if hack is active.

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -36,6 +36,7 @@ VALID_IMG_TYPES=(
     secure_demo
     niftycloud
     cloudsigma
+    nspawn
 )
 
 #list of oem package names, minus the oem- prefix
@@ -107,6 +108,9 @@ IMG_DEFAULT_BUNDLE_FORMAT=
 
 # Memory size to use in any config files
 IMG_DEFAULT_MEM=1024
+
+## systemd-nspawn
+IMG_nspawn_DISK_LAYOUT=nspawn
 
 ## qemu
 IMG_qemu_DISK_FORMAT=qcow2


### PR DESCRIPTION
 - Sets a read-only flag in the GPT so generic tools like nspawn can
   detect that /usr is supposed to be mounted read-only.
 - Adds a vm type that uses the standard x86_64 root volume type instead
   of our custom coreos-resize type.