### PR TITLE
hvm ami enable sriov on image

### DIFF
--- a/oem/ami/import.sh
+++ b/oem/ami/import.sh
@@ -188,6 +188,7 @@ hvm_amiid=$(ec2-register                              \
   --virtualization-type hvm                           \
   --root-device-name /dev/xvda                        \
   --block-device-mapping /dev/xvda=$snapshotid::true  \
+  --sriov simple                                      \
   --block-device-mapping /dev/xvdb=ephemeral0         |
   cut -f2)
 


### PR DESCRIPTION
turns out this is a really non-trivial speedup, so this turned into low hanging fruit that fell off the tree pretty quickly, figured I could share the speedup with the rest of the CoreOS world. since `ixgbevf` is already loaded on coreos, all we need to do is enable `sriov` support on the AMI itself [1]. I believe this is all we need to do, however, like most amazon docs, it's not entirely clear and there are 18 ways to skin the cat ;). per [2] this is the recommended method on 'instance-backed' but the recommended way on 'ebs-backed' is to run an instance, stop it and modify it; I believe they recommend this way in order to add the kernel module, which CoreOS already has. I have an inkling that registering the ami with the `sriov` flag will just work [on instance backed and ebs backed], provided the module is loaded. I have not tested this (though I did look into it! sorry), I am hoping it is easy for y'all to test. I did follow [1] and can confirm that it works and is totally worth it. my biggest concern would be breaking the network interface on instance families that do not support SR-IOV -- I could not find any mention of this, but I'm guessing the SR-IOV flag just gets ignored. Thanks for the great OS, I hope this will help in getting `sriov` support baked into the AMI :)

[1](https://github.com/coreos/bugs/issues/273#issuecomment-97159278)
[2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html)