### PR TITLE
image_to_vm: fix OVF filename

### DIFF
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Envelope vmw:buildId="build-1474528" xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <References>
-    <File ovf:href="@@NAME@@.vmdk" ovf:id="file1" ovf:size="@@VMDK_FILE_SIZE@@"/>
+    <File ovf:href="@@VMDK_FILE_NAME@@" ovf:id="file1" ovf:size="@@VMDK_FILE_SIZE@@"/>
   </References>
   <DiskSection>
     <Info>Virtual disk information</Info>

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -917,6 +917,7 @@ _write_ovf_vmware_conf() {
 
     sed "${BUILD_LIBRARY_DIR}/template_vmware.ovf" \
         -e "s/@@NAME@@/$(_dst_name)/g" \
+        -e "s/@@VMDK_FILE_NAME@@/$(basename ${VM_DST_IMG})/g" \
         -e "s/@@VMDK_FILE_SIZE@@/${vmdk_file_size}/g" \
         -e "s/@@VMDK_CAPACITY@@/${vmdk_capacity}/g" \
         -e "s/@@NUM_CPUS@@/${vm_cpus}/g" \


### PR DESCRIPTION
I somehow missed this before.