### PR TITLE
recognize ssh ed25519 keys

### DIFF
--- a/contrib/create-basic-configdrive
+++ b/contrib/create-basic-configdrive
@@ -31,7 +31,7 @@ ssh_authorized_keys:
   - <SSH_KEY>
 hostname: <HOSTNAME>
 "
-REGEX_SSH_FILE="^ssh-(rsa|dss) [-A-Za-z0-9+\/]+[=]{0,2} .+"
+REGEX_SSH_FILE="^ssh-(rsa|dss|ed25519) [-A-Za-z0-9+\/]+[=]{0,2} .+"
 
 while getopts "d:e:H:i:n:p:S:t:h" OPTION
 do


### PR DESCRIPTION
This extends in scripts/contrib/create-basic-configdrive the regexp matching ssh rsa and dss keys to ed25519 keys so modern crypto is supported.