### PR TITLE
dm-verity build support

### DIFF
--- a/build_image
+++ b/build_image
@@ -24,6 +24,8 @@ DEFINE_string board "${DEFAULT_BOARD}" \
   "The board to build an image for."
 DEFINE_boolean enable_rootfs_verification ${FLAGS_TRUE} \
   "Default all bootloaders to use kernel-based root fs integrity checking."
+DEFINE_boolean enable_verity ${FLAGS_FALSE} \
+  "Default GRUB to use dm-verity-enabled boot arguments"
 DEFINE_string base_pkg "coreos-base/coreos" \
   "The base portage package to base the build off of (only applies to prod images)"
 DEFINE_string base_dev_pkg "coreos-base/coreos-dev" \

--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -62,19 +62,19 @@ menuentry "CoreOS default" --id=coreos {
     gptprio.next -d usr -u usr_uuid
     if [ "$usr_uuid" = "7130c94a-213a-4e5a-8e26-6cce9662f132" ]; then
        linux$suf /coreos/vmlinuz-a $linux_console $linux_root \
-            mount.usr=PARTUUID=$usr_uuid $linux_append
+            @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_append
     else
        linux$suf /coreos/vmlinuz-b $linux_console $linux_root \
-            mount.usr=PARTUUID=$usr_uuid $linux_append
+            @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_append
     fi
 }
 
 menuentry "CoreOS USR-A" --id=coreos-a {
-    linux$suf /coreos/vmlinuz-a $linux_console $linux_root \
-         mount.usr=PARTLABEL=USR-A $linux_append
+   linux$suf /coreos/vmlinuz-a $linux_console $linux_root \
+        @@MOUNTUSR@@=PARTLABEL=USR-A $linux_append
 }
 
 menuentry "CoreOS USR-B" --id=coreos-b {
-    linux$suf /coreos/vmlinuz-b $linux_console $linux_root \
-         mount.usr=PARTLABEL=USR-B $linux_append
+   linux$suf /coreos/vmlinuz-b $linux_console $linux_root \
+        @@MOUNTUSR@@=PARTLABEL=USR-B $linux_append
 }

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -76,20 +76,7 @@ create_prod_image() {
 L+  /etc/ld.so.conf     -   -   -   -   ../usr/lib/ld.so.conf
 EOF
 
-  # Only try to disable rw on /usr if there is a /usr partition 
-  local disable_read_write=${FLAGS_enable_rootfs_verification}
-  if ! mountpoint -q "${root_fs_dir}/usr"; then
-    disable_read_write=${FLAGS_FALSE}
-  fi
-
   finish_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${image_contents}"
-
-  # Make the filesystem un-mountable as read-write and setup verity.
-  if [[ ${disable_read_write} -eq ${FLAGS_TRUE} ]]; then
-    "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout="${disk_layout}" verity \
-      --root_hash="${BUILD_DIR}/${image_name%.bin}_verity.txt" \
-      "${BUILD_DIR}/${image_name}"
-  fi
 
   upload_image -d "${BUILD_DIR}/${image_name}.bz2.DIGESTS" \
       "${BUILD_DIR}/${image_contents}" \


### PR DESCRIPTION
This adds dm-verity support to prod builds under the flag `--enable_verity`. It currently has an issue with preventing the OEM disk from mounting.