### PR TITLE
Add check for mkisofs

### DIFF
--- a/contrib/create-basic-configdrive
+++ b/contrib/create-basic-configdrive
@@ -55,6 +55,12 @@ if [ $(id -u) -eq 0 ]; then
     exit 1
 fi
 
+# mkisofs tool check
+if ! which mkisofs &>/dev/null; then
+    echo "$0: mkisofs tool is required to create image." >&2
+    exit 1
+fi
+
 if [ -z "$HNAME" ]; then
     echo "$0: The hostname parameter '-H' is required." >&2
     exit 1


### PR DESCRIPTION
This check helps to avoid exit the script with the message indicating
success even though the mkisofs is missing and an image has not been created.