### PR TITLE
build_packages: always rebuild when breaking dependency cycles

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -218,9 +218,7 @@ break_dep_loop() {
   # rebuilding zlib for some unknown reason, in turn triggering more rebuilds.
   sudo -E "${EMERGE_CMD[@]}" "${EMERGE_FLAGS[@]}" \
       --rebuild-if-unbuilt=n \
-      --binpkg-respect-use=n \
       --buildpkg-exclude="${pkg}" \
-      --useoldpkg-atoms="${pkg}" \
       ${extra_args} "${pkg}"
   sudo rm -f "${flag_file}"
 }


### PR DESCRIPTION
Previously we attempted to speed up the first build of a board by
pulling in binary packages regardless of their use flags, assuming that
if the package was already built the loop would not be an issue. Usually
this was true but not always. Now things like util-linux will always get
compiled when setting up a board for the first time but at least it
won't be as likely to fail.