### PR TITLE
bootstrap_sdk: add support for directly GPG signing SDK tarballs

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -87,7 +87,8 @@ if [[ "$STAGES" =~ stage4 ]]; then
     info "SDK ready: $BUILDS/${release_name}"
 
     def_upload_path="${UPLOAD_ROOT}/sdk/${ARCH}/${FLAGS_version}"
-    upload_files "tarball" "${def_upload_path}" "" "$BUILDS/${release_name}" \
+    sign_and_upload_files "tarball" "${def_upload_path}" "" \
+        "$BUILDS/${release_name}" \
         "$BUILDS/${release_name}.CONTENTS" "$BUILDS/${release_name}.DIGESTS"
     upload_files "packages" "${def_upload_path}" "pkgs/" "${BINPKGS}"/*
 fi


### PR DESCRIPTION
SDK tarballs have a .DIGESTS file but it is created by catalyst instead
of the upload_image function. In order to support plain GPG signing but
not avoid re-generating .DIGESTS we need to move that code out of
upload_image to a new function. upload_files shouldn't do it itself
because it is also used for portage binary packages which shouldn't be
signed (there is no point, nothing would verify the signatures).