### PR TITLE
disk_util: use the dummy disk UUID

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -269,7 +269,8 @@ def WritePartitionTable(options, config=None, partitions=None):
     config, partitions = LoadPartitionConfig(options)
 
   if options.create:
-    Cgpt('create', '-c', '-s', config['metadata']['blocks'], options.disk_image)
+    Cgpt('create', '-c', '-s', config['metadata']['blocks'],
+        '-g', '00000000-0000-0000-0000-000000000001', options.disk_image)
   else:
     # If we are not creating a fresh image all partitions must be compatible.
     GetPartitionTableFromImage(options, config, partitions)

--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -65,7 +65,7 @@ def LoadPartitionConfig(options):
     metadata = config['metadata']
     base = config['layouts']['base']
     for key in ('part_alignment', 'disk_alignment',
-		'block_size', 'fs_block_size'):
+        'block_size', 'fs_block_size'):
       metadata[key] = int(metadata[key])
   except KeyError as e:
     raise InvalidLayout('Metadata is missing required entries: %s' % e)


### PR DESCRIPTION
Depends on https://github.com/coreos/seismograph/pull/32.