### PR TITLE
grub_install: stash an exact copy of the MBR boot code.

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -160,6 +160,10 @@ case "${FLAGS_target}" in
         sudo cp "/usr/lib/grub/i386-pc/boot.img" "${ESP_DIR}/${GRUB_DIR}"
         sudo grub-bios-setup --device-map=/dev/null \
             --directory="${ESP_DIR}/${GRUB_DIR}" "${LOOP_DEV}"
+        # boot.img gets manipulated by grub-bios-setup so it alone isn't
+        # sufficient to restore the MBR boot code if it gets corrupted.
+        sudo dd bs=448 count=1 if="${LOOP_DEV}" \
+            of="${ESP_DIR}/${GRUB_DIR}/mbr.bin"
         ;;
     x86_64-efi)
         info "Installing default x86_64 UEFI bootloader."


### PR DESCRIPTION
Useful for repairing the MBR without needing GRUB's tools.