### PR TITLE
update_chroot/build_packages: remove obsolete packages

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -225,6 +225,9 @@ info "Merging board packages now"
 sudo -E "${EMERGE_CMD[@]}" "${EMERGE_FLAGS[@]}" \
     @system coreos-devel/board-packages
 
+info "Removing obsolete packages"
+sudo -E "${EMERGE_CMD[@]}" --depclean @unavailable
+
 if "portageq-${BOARD}" list_preserved_libs "${BOARD_ROOT}" >/dev/null; then
   sudo -E "${EMERGE_CMD[@]}" "${REBUILD_FLAGS[@]}" @preserved-rebuild
 fi

--- a/update_chroot
+++ b/update_chroot
@@ -226,6 +226,9 @@ info "Updating all SDK packages"
 sudo -E ${EMERGE_CMD} ${EMERGE_FLAGS} \
     coreos-devel/sdk-depends world
 
+info "Removing obsolete packages"
+sudo -E ${EMERGE_CMD} --depclean @unavailable
+
 if portageq list_preserved_libs / >/dev/null; then
   info "Rebuilding packages linked against old libraries"
   sudo -E ${EMERGE_CMD} ${REBUILD_FLAGS} @preserved-rebuild


### PR DESCRIPTION
Before attempting to do @preserved-rebuild to fix linked against old
libraries remove any packages that no longer have corresponding ebuilds,
making them impossible to rebuild. This uses `--depclean`'s secondary
meaning: `--unmerge` but only remove packages without dependencies.