### PR TITLE
scripts: Run ldconfig in qemu

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -96,6 +96,7 @@ create_dev_image() {
 
   set_image_profile dev
   emerge_to_image "${root_fs_dir}" @system ${base_pkg}
+  run_ldconfig "${root_fs_dir}"
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
   write_licenses "${root_fs_dir}" "${BUILD_DIR}/${image_licenses}"
 

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -47,6 +47,7 @@ create_prod_image() {
   set_image_profile prod
   extract_prod_gcc "${root_fs_dir}"
   emerge_to_image "${root_fs_dir}" "${base_pkg}"
+  run_ldconfig "${root_fs_dir}"
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
   write_licenses "${root_fs_dir}" "${BUILD_DIR}/${image_licenses}"
   extract_docs "${root_fs_dir}"


### PR DESCRIPTION
ldconfig does not work for non-native arches.  Create a new
build_image routine run_ldconfig that uses qemu user emulation
to run the board ldconfig on the board rootfs when the board and
SDK arches are different.

See: http://code.google.com/p/chromium/issues/detail?id=378377

Prior to calling run_ldconfig the board rootfs must have ldconfig
installed.  To arrange this move the call of run_ldconfig to after
the base package install.

Fixes build_image errors like these when building for arm64:

  /sbin/ldconfig: /lib64/libXXX is for unknown machine 183.

Depends on https://github.com/coreos/coreos-overlay/pull/1424

@marineam I'm still testing this, but wanted to get it out for your comments before I put too much into it.
/cc @andrejro
