### PR TITLE
catalyst: re-enable ccache

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -58,7 +58,7 @@ cat <<EOF
 contents="auto"
 digests="md5 sha1 sha512 whirlpool"
 hash_function="crc32"
-options="pkgcache"
+options="ccache pkgcache"
 sharedir="/usr/lib/catalyst"
 storedir="$CATALYST_ROOT"
 distdir="$DISTDIR"


### PR DESCRIPTION
Now that ccache is turned on by default in the profile portage complains
a lot if ccache isn't actually installed, sleeping 5 seconds for each
error message. Since pkgcache is in use ccache isn't going to make that
much of a difference but getting rid of those 5 second sleeps will. :)