### PR TITLE
grub: move standard kernel options to grub

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -63,35 +63,29 @@ if [ -z "$linux_console" ]; then
     fi
 fi
 
-# UEFI uses linuxefi/initrdefi instead of linux/initrd
-if [ "$grub_platform" = efi ]; then
+# UEFI uses linuxefi/initrdefi instead of linux/initrd except for arm64
+if [ "$grub_platform" = efi ] && [ "$grub_cpu" != arm64 ]; then
     set suf="efi"
 else
     set suf=""
 fi
 
-# Use standard linux command for arm64
-if [ "$grub_cpu" = arm64 ]; then
-    set suf=""
-fi
+# Assemble the options applicable to all the kernels below
+set linux_cmdline="rootflags=rw mount.usrflags=ro $linux_root $linux_console $first_boot $linux_append"
 
 menuentry "CoreOS default" --id=coreos {
     gptprio.next -d usr -u usr_uuid
     if [ "$usr_uuid" = "7130c94a-213a-4e5a-8e26-6cce9662f132" ]; then
-       linux$suf /coreos/vmlinuz-a $first_boot $linux_console $linux_root \
-            @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_append
+       linux$suf /coreos/vmlinuz-a @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_cmdline
     else
-       linux$suf /coreos/vmlinuz-b $first_boot $linux_console $linux_root \
-            @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_append
+       linux$suf /coreos/vmlinuz-b @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_cmdline
     fi
 }
 
 menuentry "CoreOS USR-A" --id=coreos-a {
-   linux$suf /coreos/vmlinuz-a $first_boot $linux_console $linux_root \
-        @@MOUNTUSR@@=PARTLABEL=USR-A $linux_append
+   linux$suf /coreos/vmlinuz-a @@MOUNTUSR@@=PARTLABEL=USR-A $linux_cmdline
 }
 
 menuentry "CoreOS USR-B" --id=coreos-b {
-   linux$suf /coreos/vmlinuz-b $first_boot $linux_console $linux_root \
-        @@MOUNTUSR@@=PARTLABEL=USR-B $linux_append
+   linux$suf /coreos/vmlinuz-b @@MOUNTUSR@@=PARTLABEL=USR-B $linux_cmdline
 }


### PR DESCRIPTION
In order to boot properly we need `rootflags=rw mount.usrflags=ro` on
the command line. These have been build into the kernel directly but for
arm64 builds the built in options seem to be ignored.