### PR TITLE
Fixed typo on URI for DEFAULT_ETCD_DISCOVERY.

### DIFF
--- a/contrib/create-basic-configdrive
+++ b/contrib/create-basic-configdrive
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEFAULT_ETCD_DISCOVERY="https//discovery.etcd.io/TOKEN"
+DEFAULT_ETCD_DISCOVERY="https://discovery.etcd.io/TOKEN"
 DEFAULT_ETCD_ADDR="http://\$public_ipv4:2379"
 DEFAULT_ETCD_PEER_URLS="http://\$private_ipv4:2380"
 DEFAULT_ETCD_LISTEN_PEER_URLS="http://0.0.0.0:2380"


### PR DESCRIPTION
The DEFAULT_ETCD_DISCOVERY parameter had a typo in the scheme part of the URI. It missed a colon after https.
This lead to failure on the discovery of the cluster when the token based discovery was used as the https://discovery.etcd.io could not be reached during the boot/configuration process. 