### PR TITLE
grub: add and set coreos.randomize_disk_guid kernel param

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -15,6 +15,7 @@ set timeout=1
 set linux_root="root=LABEL=ROOT"
 set linux_console=""
 set first_boot=""
+set randomize_disk_guid=""
 set oem_id=""
 
 # Anything else the OEM adds should use this variable.
@@ -43,6 +44,8 @@ search --no-floppy --set first_boot \
        --disk-uuid 00000000-0000-0000-0000-000000000001
 if [ -n "$first_boot" ]; then
     set first_boot="coreos.first_boot=1"
+    # Explicitly request the disk-guid randomization
+    set randomize_disk_guid="coreos.randomize_disk_guid=1"
 fi
 
 if [ -n "$oem_id" ]; then
@@ -76,7 +79,7 @@ else
 fi
 
 # Assemble the options applicable to all the kernels below
-set linux_cmdline="rootflags=rw mount.usrflags=ro $linux_root $linux_console $first_boot $oem_id $linux_append"
+set linux_cmdline="rootflags=rw mount.usrflags=ro $linux_root $linux_console $first_boot $randomize_disk_guid $oem_id $linux_append"
 
 menuentry "CoreOS default" --id=coreos {
     gptprio.next -d usr -u usr_uuid


### PR DESCRIPTION
coreos.first_boot=1 will no longer trigger disk-guid randomization, so
manual ignition triggers in diskless/pxe scenarios may succeed.  Instead
we explicitly request the randomization when first_boot=1 was added by
grub finding the 00000000-0000-0000-0000-000000000001 disk-guid.