### PR TITLE
grub: disable console blanking

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -77,7 +77,7 @@ else
 fi
 
 # Assemble the options applicable to all the kernels below
-set linux_cmdline="rootflags=rw mount.usrflags=ro $linux_root $linux_console $first_boot $oem_id $linux_append"
+set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $oem_id $linux_append"
 
 menuentry "CoreOS default" --id=coreos {
     gptprio.next -d usr -u usr_uuid


### PR DESCRIPTION
The console often contains very useful information in the event of a
hard crash, in such situations there's no ability to unblank the console
via keypress because the kernel won't handle the interrupt.

Since CoreOS is a server/cluster operating system, there won't generally
be monitors connected benefitting from a blanked console.  Disabling the
blanking altogether allows the frame buffer contents to always be
visible, even when the kernel can't handle keypresses.