### PR TITLE
Updates for jenkins builds

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -231,6 +231,7 @@ load_environment_whitelist() {
     GIT_PROXY_COMMAND
     GIT_SSH
     RSYNC_PROXY
+    GNUPGHOME
     GPG_AGENT_INFO
     SSH_AGENT_PID
     SSH_AUTH_SOCK

--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -293,9 +293,10 @@ setup_env() {
     fi
 
     # Mount GnuPG's data directory for signing uploads
-    if [[ -d "$SUDO_HOME/.gnupg" ]]; then
+    : ${GNUPGHOME:="$SUDO_HOME/.gnupg"}
+    if [[ -d "${GNUPGHOME}" ]]; then
       debug "Mounting GnuPG"
-      setup_mount "${SUDO_HOME}/.gnupg" "--bind" "/home/${SUDO_USER}/.gnupg"
+      setup_mount "${GNUPGHOME}" "--bind" "${GNUPGHOME}"
 
       # bind mount the gpg agent dir if available
       GPG_AGENT_DIR="${GPG_AGENT_INFO%/*}"


### PR DESCRIPTION
 - Support arbitrary $GNUPGHOME values, avoiding conflicts in $HOME for jenkins builders.
 - Allow setting COREOS_BUILD_ID in the environment so it can be mapped directly to a jenkins job instead of using the date.