### PR TITLE
enter_chroot: fix chroot root bind command

### DIFF
--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -218,7 +218,7 @@ setup_env() {
 
     # Make sure the new root directory itself is a mount point. Tools like
     # unshare assume that things like `mount --make-rprivate /` work.
-    setup_mount "${MOUNTED_PATH}" "--bind" /
+    setup_mount "${MOUNTED_PATH}" "--rbind" /
 
     setup_mount none "-t proc" /proc
     setup_mount none "-t sysfs" /sys


### PR DESCRIPTION
Commit 09851b84 didn't do a recursive bind by mistake, so if the host
system has anything mounted under the chroot directory for some reason
the bind would hide those mounts. Recursive ensures existing mounts
remain exposed as they did before.