### PR TITLE
setup_board: Build grub platform modules

### DIFF
--- a/setup_board
+++ b/setup_board
@@ -320,3 +320,6 @@ fi
 
 # Setup BOARD_ROOT for QEMU user emulation.
 setup_qemu_static "${BOARD_ROOT}"
+
+# Build grub platform modules if needed.
+sudo -E emerge --changed-use sys-boot/grub


### PR DESCRIPTION
PR https://github.com/coreos/scripts/pull/478 added the pieces to allow us to build the grub modules for arm64 boards, but the user still needed to run emerge by hand to build them.

This PR automates that by running the emerge of the SDK sys-boot/grub again at the very end of setup_board to pick up any config changes that were made within setup_board.  This late emerge is not specific to arm64 and will build grub modules for any architecture that is different from the host.