### PR TITLE
core_date: dumb little script so I can stop doing math

### DIFF
--- a/core_date
+++ b/core_date
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright (c) 2016 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+SCRIPT_ROOT=$(dirname $(readlink -f "$0"))
+. "${SCRIPT_ROOT}/common.sh" || exit 1
+
+if [[ "$1" == "-v" ]]; then
+    shift
+    if [[ $# -ge 1 ]] && [[ "$1" != [-+]* ]]; then
+        v="$1"
+        shift
+    else
+        v="${COREOS_VERSION}"
+    fi
+
+    # strip of a v prefix or .0.0 suffix
+    v="${v#v}"
+    v="${v%%.*}"
+
+    export TZ=${TZ:=UTC}
+    date -d @$(( (v * 86400) + COREOS_EPOCH )) "$@"
+else
+    t=$(date +%s "$@")
+    echo $(( (t - COREOS_EPOCH) / 86400 ))
+fi


### PR DESCRIPTION
Compute coreos version for a date or the date of a coreos version.
Arguments are passed to `date` except for `-v` which takes an optional
version value and converts it to a date. `-v` must be the first arg.

    $ ./core_date
    945
    $ ./core_date -d wed
    947
    $ ./core_date -v
    Fri Jan 29 00:00:00 UTC 2016
    $ ./core_date -v +%D
    01/29/16
    $ ./core_date -v 1000
    Sun Mar 27 00:00:00 UTC 2016
    $ ./core_date -v 1000 +%D
    03/27/16