### PR TITLE
core_promote: switch from gsutil cp to rsync

### DIFF
--- a/core_promote
+++ b/core_promote
@@ -88,7 +88,10 @@ if [[ ${FLAGS_do_roller} -eq ${FLAGS_TRUE} ]]; then
 fi
 
 if [[ ${FLAGS_do_storage} -eq ${FLAGS_TRUE} ]]; then
-    gsutil -m cp "${gs_build}/*" "${gs_release}/"
+    # note: do not use the delete (-d) flag here since this script uploads
+    # coreos_production_gce.txt to $gs_release but not $gs_build.
+    # TODO: maybe fix that ;-)
+    gsutil -m rsync "${gs_build}/" "${gs_release}/"
 fi
 
 if [[ ${FLAGS_do_gce} -eq ${FLAGS_TRUE} ]]; then
@@ -124,19 +127,19 @@ if [[ ${FLAGS_do_gce} -eq ${FLAGS_TRUE} ]]; then
 fi
 
 if [[ ${FLAGS_do_storage} -eq ${FLAGS_TRUE} ]]; then
-    gsutil -m cp "${gs_release}/*" "${gs_current}/"
+    gsutil -m rsync -d "${gs_release}/" "${gs_current}/"
 fi
 
 if [[ ${FLAGS_do_storage} -eq ${FLAGS_TRUE} ]] && \
    [[ -n "${FLAGS_legacy_storage}" ]]
 then
     if [[ "${lower_channel}" == alpha ]]; then
-        gsutil -m cp "${gs_release}/*" \
+        gsutil -m rsync -d "${gs_release}/" \
             "${FLAGS_legacy_storage}/${FLAGS_board}/${FLAGS_version}/"
-        gsutil -m cp "${gs_current}/*" \
+        gsutil -m rsync -d "${gs_current}/" \
             "${FLAGS_legacy_storage}/${FLAGS_board}/alpha/"
     elif [[ "${lower_channel}" == beta ]]; then
-        gsutil -m cp "${gs_current}/*" \
+        gsutil -m rsync -d "${gs_current}/" \
             "${FLAGS_legacy_storage}/${FLAGS_board}/beta/"
     fi
 fi


### PR DESCRIPTION
This cleans out some old crud:

```
Removing gs://alpha.release.core-os.net/amd64-usr/current/au-generator.zip
Removing gs://alpha.release.core-os.net/amd64-usr/current/au-generator.zip.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/au-generator.zip.DIGESTS.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/au-generator.zip.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/au-generator.zip.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_developer_image.bin.bz2
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_developer_image.bin.bz2.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_developer_image.bin.bz2.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_developer_image.bin.bz2.DIGESTS.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_developer_image.bin.bz2.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_niftycloud.vmx
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_niftycloud.vmx.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_teeth.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_rackspace_vhd_image.vhd
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_teeth.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_teeth_image.img.bz2
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_teeth_image.img.bz2.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_update.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_teeth_image.img.bz2.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_teeth.DIGESTS.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_update.gz.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_update.gz
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_update.meta.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_update.DIGESTS.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_update.meta
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant.README
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.README
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_teeth_image.img.bz2.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_update.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant.README.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_virtualbox.ovf.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_virtualbox.ovf.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.README.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vmware_ova.ova.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vmware_ova.ova.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vmware.vmx.DIGESTS.asc
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_vmware.vmx.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_xen_image.vhd.bz2.sig
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_xen_image.vhd.bz2
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_xen_image.vhd.bz2.DIGESTS
Removing gs://alpha.release.core-os.net/amd64-usr/current/coreos_production_xen_image.vhd.bz2.DIGESTS.asc
```