### PR TITLE
enable spaces in path names, add minimum error handling

### DIFF
--- a/contrib/create-basic-configdrive
+++ b/contrib/create-basic-configdrive
@@ -171,7 +171,7 @@ CLOUD_CONFIG="${CLOUD_CONFIG/<HOSTNAME>/${HNAME}}"
 
 echo "$CLOUD_CONFIG" > "$CONFIG_FILE"
 
-mkisofs -R -V config-2 -o $CONFIGDRIVE_FILE $WORKDIR
+mkisofs -R -V config-2 -o "$CONFIGDRIVE_FILE" "$WORKDIR"
 
 echo
 echo

--- a/contrib/create-basic-configdrive
+++ b/contrib/create-basic-configdrive
@@ -173,8 +173,13 @@ echo "$CLOUD_CONFIG" > "$CONFIG_FILE"
 
 mkisofs -R -V config-2 -o "$CONFIGDRIVE_FILE" "$WORKDIR"
 
-echo
-echo
-echo "Success! The config-drive image was created on ${CONFIGDRIVE_FILE}"
-
+if [ "$?" -eq 0 ] ; then
+    echo
+    echo
+    echo "Success! The config-drive image was created on ${CONFIGDRIVE_FILE}"
+else
+    echo
+    echo
+    echo "Failure! The config-drive image was not created on ${CONFIGDRIVE_FILE}"
+fi
 # vim: ts=4 et


### PR DESCRIPTION
create-coreos-vdi fails to properly quote paths containing spaces, which may result in a failing execution of mkisofs. Due to missing error handling on this, create-coreos-vdi would also claim "Success" while the mkisofs execution actually failed.

This patch does add the missing quotes around "CONFIGDRIVE_FILE" (and around WORKDIR, just for completeness). It also adds a simple error message on a failed mkisofs operation.