### PR TITLE
check_root: add test for missing interpreters

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -122,6 +122,9 @@ emerge_to_image() {
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
       emerge --root-deps=rdeps --usepkgonly --jobs=$FLAGS_jobs -v "$@"
 
+  # Shortcut if this was just baselayout
+  [[ "$*" == *sys-apps/baselayout ]] && return
+
   # Make sure profile.env has been generated
   sudo -E ROOT="${root_fs_dir}" env-update --no-ldconfig
 

--- a/build_library/check_root
+++ b/build_library/check_root
@@ -6,6 +6,8 @@
 
 from __future__ import unicode_literals
 
+import fnmatch
+import os
 import sys
 
 import portage
@@ -71,6 +73,12 @@ IGNORE_MISSING = {
 }
 
 USR_LINKS = ("/bin/", "/sbin/", "/lib/", "/lib32/", "/lib64/")
+
+IGNORE_SHEBANG = (
+    b"*/python2.7/cgi.py",
+    b"*/usr/lib64/modules/*/source/scripts/*",
+    b"*/usr/share/nova-agent/*/etc/gentoo/nova-agent",
+)
 
 def provided_sonames():
     for cpv in VARDB.cpv_all():
@@ -147,6 +155,29 @@ def check_usr():
         ok = False
     return ok
 
+def check_shebang():
+    ok = True
+    cache = {}
+    root = os.environ.get("ROOT", b"/")
+    for parent, _, files in os.walk(root):
+        for path in [os.path.join(parent, f) for f in files]:
+            if any(fnmatch.fnmatchcase(path,i) for i in IGNORE_SHEBANG):
+                continue
+            if not os.access(path, os.R_OK|os.X_OK):
+                continue
+            with open(path, "r") as fd:
+                line = fd.readline(80)
+                if not line.startswith(b"#!"):
+                    continue
+                cmd = line[2:].rstrip().split(None,1)[0]
+                if cmd not in cache:
+                    cache[cmd] = os.path.exists(root+cmd)
+                if not cache[cmd]:
+                    relpath = path[len(root):]
+                    error("%s: %s does not exist", relpath, cmd)
+                    ok = False
+    return ok
+
 def error(fmt, *args):
     sys.stderr.write(output.red(fmt % args))
     sys.stderr.write("\n")
@@ -156,6 +187,7 @@ def main():
     check_funcs = {
             "libs": check_libs,
             "usr": check_usr,
+            "shebang": check_shebang,
     }
 
     if not sys.stderr.isatty():

--- a/build_library/check_root
+++ b/build_library/check_root
@@ -160,7 +160,7 @@ def check_usr():
 def is_exe(path):
     # just check other, assuming root or group only commands are not scripts.
     perms = stat.S_IROTH|stat.S_IXOTH
-    mode = os.stat(path).st_mode
+    mode = os.lstat(path).st_mode
     return stat.S_ISREG(mode) and mode&perms == perms
 
 def check_shebang():

--- a/build_library/check_root
+++ b/build_library/check_root
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import fnmatch
 import os
+import stat
 import sys
 
 import portage
@@ -78,6 +79,7 @@ IGNORE_SHEBANG = (
     b"*/python2.7/cgi.py",
     b"*/usr/lib64/modules/*/source/scripts/*",
     b"*/usr/share/nova-agent/*/etc/gentoo/nova-agent",
+    b"*/tmp/*",
 )
 
 def provided_sonames():
@@ -155,6 +157,12 @@ def check_usr():
         ok = False
     return ok
 
+def is_exe(path):
+    # just check other, assuming root or group only commands are not scripts.
+    perms = stat.S_IROTH|stat.S_IXOTH
+    mode = os.stat(path).st_mode
+    return stat.S_ISREG(mode) and mode&perms == perms
+
 def check_shebang():
     ok = True
     cache = {}
@@ -163,7 +171,7 @@ def check_shebang():
         for path in [os.path.join(parent, f) for f in files]:
             if any(fnmatch.fnmatchcase(path,i) for i in IGNORE_SHEBANG):
                 continue
-            if not os.access(path, os.R_OK|os.X_OK):
+            if not is_exe(path):
                 continue
             with open(path, "r") as fd:
                 line = fd.readline(80)

--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -36,5 +36,11 @@ test_image_content() {
     returncode=1
   fi
 
+  # Check that there are no #! lines pointing to non-existant locations
+  if ! ROOT="$root" "$check_root" shebang; then
+    error "test_image_content: Failed #! check"
+    returncode=1
+  fi
+
   return $returncode
 }


### PR DESCRIPTION
Not ready for merge, the errors it raises should be fixed first:

```
/usr/bin/diff-highlight: /usr/bin/perl does not exist
/usr/bin/mtrace: /usr/bin/perl does not exist
/usr/bin/glib-mkenums: /usr/bin/perl does not exist
/usr/bin/import-tars: /usr/bin/perl does not exist
/usr/share/rsync/rsyncstats: /usr/bin/perl does not exist
/usr/share/rsync/git-set-file-times: /usr/bin/perl does not exist
/usr/share/rsync/lsh: /usr/bin/perl does not exist
/usr/share/rsync/rrsync: /usr/bin/perl does not exist
/usr/share/rsync/mapto: /usr/bin/perl does not exist
/usr/share/rsync/mnt-excl: /usr/bin/perl does not exist
/usr/share/rsync/munge-symlinks: /usr/bin/perl does not exist
/usr/share/rsync/cvs2includes: /usr/bin/perl does not exist
/usr/share/rsync/file-attr-restore: /usr/bin/perl does not exist
/usr/share/rsync/logfilter: /usr/bin/perl does not exist
/usr/share/rsync/files-to-excludes: /usr/bin/perl does not exist
/usr/share/rsync/mapfrom: /usr/bin/perl does not exist
/usr/share/rsync/atomic-rsync: /usr/bin/perl does not exist
/usr/share/git/contrib/fast-import/git-import.perl: /usr/bin/perl does not exist
/usr/share/git/contrib/fast-import/import-directories.perl: /usr/bin/perl does not exist
/usr/share/git/contrib/fast-import/import-tars.perl: /usr/bin/perl does not exist
/usr/share/git/contrib/stats/packinfo.pl: /usr/bin/perl does not exist
/usr/share/git/contrib/stats/mailmap.pl: /usr/bin/perl does not exist
/usr/share/git/contrib/hooks/update-paranoid: /usr/bin/perl does not exist
/usr/share/git/contrib/hooks/setgitperms.perl: /usr/bin/perl does not exist
/usr/share/git/contrib/buildsystems/generate: /usr/bin/perl does not exist
/usr/share/git/contrib/buildsystems/engine.pl: /usr/bin/perl does not exist
/usr/share/git/contrib/buildsystems/parse.pl: /usr/bin/perl does not exist
/usr/libexec/selinux/semanage_migrate_store: /usr/bin/python does not exist
/usr/libexec/git-core/git-contacts: /usr/bin/perl does not exist
/usr/sbin/ebtables-save: /usr/bin/perl does not exist
/usr/sbin/nfsiostat: /usr/bin/python does not exist
/etc/ssl/misc/CA.pl: /usr/bin/perl does not exist
/etc/ssl/misc/tsget: /usr/bin/perl does not exist
```

See https://github.com/coreos/bugs/issues/1139 https://github.com/coreos/bugs/issues/597 https://github.com/coreos/bugs/issues/1105 and probably others