### PR TITLE
prod_image_util: move profile.env to /usr

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -91,6 +91,9 @@ create_prod_image() {
   sudo rm -rf ${root_fs_dir}/etc/env.d
   sudo rm -rf ${root_fs_dir}/var/db/pkg
 
+  sudo mv ${root_fs_dir}/etc/profile.env \
+      ${root_fs_dir}/usr/share/baselayout/profile.env
+
   # Move the ld.so configs into /usr so they can be symlinked from /
   sudo mv ${root_fs_dir}/etc/ld.so.conf ${root_fs_dir}/usr/lib
   sudo mv ${root_fs_dir}/etc/ld.so.conf.d ${root_fs_dir}/usr/lib


### PR DESCRIPTION
profile is already set up to source /usr/share/baselayout/profile.env
but it never has because I forgot to add this line during the migration
to amd64-usr images. Sure took us a while to notice that one... :(