### PR TITLE
oem/ami/copy_ami.sh: nuke parallelism

### DIFF
--- a/oem/ami/copy_ami.sh
+++ b/oem/ami/copy_ami.sh
@@ -143,29 +143,14 @@ do_copy() {
     echo "AMI $virt_type copy to $r as $r_amiid in complete"
 }
 
-WAIT_PIDS=()
 for r in "${REGIONS[@]}"
 do
     [ "${r}" == "${region}" ] && continue
-    do_copy "$r" pv "$AMI" &
-    WAIT_PIDS+=( $! )
+    do_copy "$r" pv "$AMI"
     if [[ -n "$HVM" ]]; then
-        do_copy "$r" hvm "$HVM" &
-        WAIT_PIDS+=( $! )
+        do_copy "$r" hvm "$HVM"
     fi
 done
-
-# wait for each subshell individually to report errors
-WAIT_FAILED=0
-for wait_pid in "${WAIT_PIDS[@]}"; do
-    if ! wait ${wait_pid}; then
-        : $(( WAIT_FAILED++ ))
-    fi
-done
-
-if [[ ${WAIT_FAILED} -ne 0 ]]; then
-    echo "${WAIT_FAILED} jobs failed :(" >&2
-    exit ${WAIT_FAILED}
-fi
 
 echo "Done"
+


### PR DESCRIPTION
there's now 10 regions, so about 20 processes are going to be spawned to
copy pv/hvm images. since we're using the java ec2 tools, this consumes
a lot of memory, and causes unnecessary trouble when one of those
subprocesses is killed due to OOM.