### PR TITLE
Move PAM configuration to /usr at build time

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -107,6 +107,9 @@ create_prod_image() {
 L+  /etc/ld.so.conf     -   -   -   -   ../usr/lib/ld.so.conf
 EOF
 
+  # Move the PAM configuration into /usr
+  sudo mv ${root_fs_dir}/etc/pam.d ${root_fs_dir}/usr/lib
+
   finish_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${image_contents}"
 
   upload_image -d "${BUILD_DIR}/${image_name}.bz2.DIGESTS" \


### PR DESCRIPTION
A bunch of packages install PAM configuration fragments in /etc. Rather than modify
them all to install into /usr/lib, just move the entire directory at image build
time.