### PR TITLE
build_library: use lib for tmpfiles rather than lib64

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -102,7 +102,7 @@ create_prod_image() {
   sudo ln --symbolic ../usr/lib/ld.so.conf ${root_fs_dir}/etc/ld.so.conf
 
   # Add a tmpfiles rule that symlink ld.so.conf from /usr into /
-  sudo tee "${root_fs_dir}/usr/lib64/tmpfiles.d/baselayout-ldso.conf" \
+  sudo tee "${root_fs_dir}/usr/lib/tmpfiles.d/baselayout-ldso.conf" \
       > /dev/null <<EOF
 L+  /etc/ld.so.conf     -   -   -   -   ../usr/lib/ld.so.conf
 EOF


### PR DESCRIPTION
in arm64-usr, lib is not yet a symlink to arm64, so trying to access
tmpfiles.d in lib64 will not work.