### PR TITLE
Increase the size of /usr on devel images

### DIFF
--- a/build_image
+++ b/build_image
@@ -137,6 +137,8 @@ fi
 mkdir -p "${BUILD_DIR}"
 
 DISK_LAYOUT="${FLAGS_disk_layout:-base}"
+DEV_DISK_LAYOUT="${FLAGS_disk_layout:-devel}"
+
 CONTAINER_LAYOUT="${FLAGS_disk_layout:-container}"
 
 if [[ -n "${FLAGS_developer_data}" ]]; then
@@ -159,9 +161,9 @@ fi
 fix_mtab
 
 if [[ "${DEV_IMAGE}" -eq 1 ]]; then
-  create_dev_image ${COREOS_DEVELOPER_IMAGE_NAME} ${DISK_LAYOUT} ${FLAGS_group} ${FLAGS_base_dev_pkg}
+  create_dev_image ${COREOS_DEVELOPER_IMAGE_NAME} ${DEV_DISK_LAYOUT} ${FLAGS_group} ${FLAGS_base_dev_pkg}
   if [[ ${FLAGS_extract_update} -eq ${FLAGS_TRUE} ]]; then
-    extract_update "${COREOS_DEVELOPER_IMAGE_NAME}" "${DISK_LAYOUT}"
+    extract_update "${COREOS_DEVELOPER_IMAGE_NAME}" "${DEV_DISK_LAYOUT}"
   fi
 fi
 

--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -70,6 +70,29 @@
         "mount":"/"
       }
     },
+    "devel": {
+      "3":{
+        "label":"USR-A",
+        "uuid":"7130c94a-213a-4e5a-8e26-6cce9662f132",
+        "type":"coreos-rootfs",
+	"blocks":"4194304",
+	"fs_blocks":"520188",
+        "fs_type":"ext2",
+        "mount":"/usr",
+        "features": ["prioritize", "verity"]
+      },
+      "4":{
+        "label":"USR-B",
+        "uuid":"e03dd35c-7c2d-4a47-b3fe-27f15780a57c",
+        "type":"coreos-rootfs",
+	"blocks":"4194304",
+	"fs_blocks":"520188"
+      },
+      "9":{
+        "label":"ROOT",
+        "blocks":"12943360"
+      }
+    },
     "vm":{
       "9":{
         "label":"ROOT",

--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -115,6 +115,10 @@ trap vm_cleanup EXIT
 
 fix_mtab
 
+if [[ "${FLAGS_prod_image}" -eq "${FLAGS_FALSE}" && "${FLAGS_disk_layout}" == "" ]]; then
+    FLAGS_disk_layout=devel
+fi
+
 # Setup new (raw) image, possibly resizing filesystems
 setup_disk_image "${FLAGS_disk_layout}"
 


### PR DESCRIPTION
devel images contain significantly more code and we're overflowing the
filesystem. Increase this, but only for devel images.