### PR TITLE
build_image: disable verity on arm64

### DIFF
--- a/build_image
+++ b/build_image
@@ -88,6 +88,11 @@ switch_to_strict_mode
 
 check_gsutil_opts
 
+# Inserting the verity hash into the kernel assumes x86_64
+if [[ "${FLAGS_board}" != amd64-usr ]]; then
+  FLAGS_enable_rootfs_verification=${FLAGS_FALSE}
+fi
+
 # If downloading packages is enabled ensure the board is configured properly.
 if [[ ${FLAGS_getbinpkg} -eq ${FLAGS_TRUE} ]]; then
   "${SRC_ROOT}/scripts/setup_board" --board="${FLAGS_board}" \


### PR DESCRIPTION
Our current scheme injects the verity hash into a free spot in x86
kernel images. This is a bad thing to try on other types ;-)

Smaller alternative to https://github.com/coreos/scripts/pull/521 and https://github.com/coreos/scripts/pull/522