### PR TITLE
prod_image_util: do not check update keys on arm64

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -81,7 +81,7 @@ create_prod_image() {
 
   # Assert that if this is supposed to be an official build that the
   # official update keys have been used.
-  if [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
+  if [[ ${COREOS_OFFICIAL:-0} -eq 1 && "${BOARD}" != arm64-usr ]]; then
       grep -q official \
           "${root_fs_dir}"/var/db/pkg/coreos-base/coreos-au-key-*/USE \
           || die_notrace "coreos-au-key is missing the 'official' use flag"


### PR DESCRIPTION
arm64-usr doesn't have update_engine yet so this isn't valid.