### PR TITLE
add support for genisoimage

### DIFF
--- a/contrib/create-basic-configdrive
+++ b/contrib/create-basic-configdrive
@@ -68,9 +68,13 @@ if [ $(id -u) -eq 0 ]; then
     exit 1
 fi
 
-# mkisofs tool check
-if ! which mkisofs &>/dev/null; then
-    echo "$0: mkisofs tool is required to create image." >&2
+# mkisofs/genisoimage tool check
+if which mkisofs &>/dev/null; then
+    mkisofs=$(which mkisofs)
+elif which genisoimage &>/dev/null; then
+    mkisofs=$(which genisoimage)
+else 
+    echo "$0: mkisofs or genisoimage tool is required to create image." >&2
     exit 1
 fi
 
@@ -171,7 +175,7 @@ CLOUD_CONFIG="${CLOUD_CONFIG/<HOSTNAME>/${HNAME}}"
 
 echo "$CLOUD_CONFIG" > "$CONFIG_FILE"
 
-mkisofs -R -V config-2 -o "$CONFIGDRIVE_FILE" "$WORKDIR"
+$mkisofs -R -V config-2 -o "$CONFIGDRIVE_FILE" "$WORKDIR"
 
 if [ "$?" -eq 0 ] ; then
     echo


### PR DESCRIPTION
Debian (and possibly other distros) no longer ship mkisofs in favor of genisoimage. This MR adds genisoimage support to `contrib/create-basic-configdrive` script.

Thank you, ciao