### PR TITLE
*: drop obsolete gentoo repo reference

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -86,9 +86,6 @@ cat <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
-[gentoo]
-disabled = true
-
 [coreos]
 location = /usr/portage
 

--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -33,9 +33,6 @@ sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
-[gentoo]
-disabled = true
-
 [coreos]
 location = /var/lib/portage/coreos-overlay
 sync-type = git

--- a/update_chroot
+++ b/update_chroot
@@ -99,9 +99,6 @@ sudo_clobber "/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
-[gentoo]
-disabled = true
-
 [coreos]
 location = ${COREOS_OVERLAY}
 


### PR DESCRIPTION
Instead of patching portage to support the `disabled` flag now we just
patch it to leave the `[gentoo]` section out of the default repos.conf.

Follow up to https://github.com/coreos/coreos-overlay/commit/585275b268da9f549d93c7c37744dcda3411cca2