### PR TITLE
Revert "*: drop obsolete gentoo repo reference"

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -86,6 +86,9 @@ cat <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
+[gentoo]
+disabled = true
+
 [coreos]
 location = /usr/portage
 

--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -33,6 +33,9 @@ sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
+[gentoo]
+disabled = true
+
 [coreos]
 location = /var/lib/portage/coreos-overlay
 sync-type = git

--- a/update_chroot
+++ b/update_chroot
@@ -99,6 +99,9 @@ sudo_clobber "/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
+[gentoo]
+disabled = true
+
 [coreos]
 location = ${COREOS_OVERLAY}
 


### PR DESCRIPTION
Reverts coreos/scripts#538

Not everyone has flushed older versions of portage out of their systems yet. Keep these compatibility configs for a bit longer.