### PR TITLE
enter_chroot: do not export variables that weren't previously exported

### DIFF
--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -394,7 +394,11 @@ CHROOT_PASSTHRU=(
 # Add the whitelisted environment variables to CHROOT_PASSTHRU.
 load_environment_whitelist
 for var in "${ENVIRONMENT_WHITELIST[@]}" ; do
-  [ "${!var+set}" = "set" ] && CHROOT_PASSTHRU+=( "${var}=${!var}" )
+  # skip empty/unset values
+  [[ "${!var+set}" == "set" ]] || continue
+  # skip values that aren't actually exported
+  [[ $(declare -p "${var}") == "declare -x ${var}="* ]] || continue
+  CHROOT_PASSTHRU+=( "${var}=${!var}" )
 done
 
 # Set up GIT_PROXY_COMMAND so git:// URLs automatically work behind a proxy.


### PR DESCRIPTION
COREOS_BUILD_ID is set to a default value in common.sh if unset in the
environment. When entering the chroot this default value should not then
get promoted into the environment. Doing so causes catalyst to re-use
stale builds and multiple build_image runs to conflict with each other.