### PR TITLE
oem: inflate images into /var/tmp

### DIFF
--- a/oem/ami/import.sh
+++ b/oem/ami/import.sh
@@ -127,7 +127,7 @@ fi
 export EC2_URL="https://ec2.${region}.amazonaws.com"
 echo "Building AMI in zone ${EC2_IMPORT_ZONE}"
 
-tmpdir=$(mktemp -d)
+tmpdir=$(mktemp --directory --tmpdir=/var/tmp)
 trap "rm -rf '${tmpdir}'" EXIT
 
 # if it is on the local fs, just use it, otherwise try to download it

--- a/oem/azure/publish.sh
+++ b/oem/azure/publish.sh
@@ -11,7 +11,7 @@ DIR=$(dirname $0)
 
 set -e
 
-WORKDIR=$(mktemp --directory)
+WORKDIR=$(mktemp --directory --tmpdir=/var/tmp)
 trap "rm --force --recursive ${WORKDIR}" SIGINT SIGTERM EXIT
 
 IMAGE_PATH="${WORKDIR}/coreos_production_azure_image.vhd"


### PR DESCRIPTION
tmpfs shouldn't be used for large images like this. Inflate the archives
on disk instead.