### PR TITLE
Glance image API v1 must now be explicitly specified by the client

### DIFF
--- a/oem/openstack/glance_load.sh
+++ b/oem/openstack/glance_load.sh
@@ -51,7 +51,7 @@ curl --fail -s -L ${image_url} |  bunzip2 > ${coreosimg}
 # perform actual image creation
 #  here we set the os_release, os_verison, os_family, and os_distro variables
 #  for intelligent consumption of images by scripts
-glance image-create --name CoreOS-${release}-v${COREOS_VERSION} --progress \
+glance --os-image-api-version 1 image-create --name CoreOS-${release}-v${COREOS_VERSION} --progress \
   --is-public true --property os_distro=coreos --property os_family=coreos \
   --property os_version=${COREOS_VERSION} \
   --disk-format qcow2 --container-format bare --min-disk 6 --file $coreosimg


### PR DESCRIPTION
The OpenStack client `glance` option `--is-public true` is limited to Image API version 1, and so doesn't work with versions of the glance client where version 2 is the default.

`python-glanceclient` 1.0.0 was the first to do so, and was released Sep 2015, so most new users of this script will need this fix.