### PR TITLE
*: Fix PIPESTATUS checks for bash 4.3

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -383,9 +383,13 @@ install_cross_libs() {
 gcc_get_latest_profile() {
     local prefix="${1}-"
     local suffix="${2+-$2}"
+    local status
     gcc-config -l | cut -d' ' -f3 | grep "^${prefix}[0-9\\.]*${suffix}$" | tail -n1
+
     # return 1 if anything in the above pipe failed
-    [[ -z ${PIPESTATUS[*]#0} ]] || return 1
+    for status in ${PIPESTATUS[@]}; do
+        [[ $status -eq 0 ]] || return 1
+    done
 }
 
 # Update to the latest GCC profile for a given CHOST if required

--- a/common.sh
+++ b/common.sh
@@ -718,7 +718,7 @@ make_digests() {
 # Usage: verify_digests [-d file.DIGESTS] file1 [file2...]
 # If -d is not specified file1.DIGESTS will be used
 verify_digests() {
-    local digests
+    local digests filename hash_type status
     if [[ "$1" == "-d" ]]; then
         [[ -n "$2" ]] || die "-d requires an argument"
         digests="$(readlink -f "$2")"
@@ -735,7 +735,9 @@ verify_digests() {
             grep -A1 -i "^# ${hash_type} HASH$" "${digests}" | \
                 grep "$filename$" | ${hash_type}sum -c - --strict || return 1
             # Also check that none of the greps failed in the above pipeline
-            [[ -z ${PIPESTATUS[*]#0} ]] || return 1
+            for status in ${PIPESTATUS[@]}; do
+                [[ $status -eq 0 ]] || return 1
+            done
         done
     done
     popd >/dev/null


### PR DESCRIPTION
The one-liner `[[ -z ${PIPESTATUS[*]#0} ]]` no longer works because the
expansion still includes spaces even if all the values are zero. Somehow
that didn't matter in bash 4.2 but it does mater in 4.3 to be consistent
with the general behavior of variables in [[ tests.