### PR TITLE
build_packages: fix @preserved-rebuild

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -237,7 +237,7 @@ sudo -E "${EMERGE_CMD[@]}" "${EMERGE_FLAGS[@]}" "$@"
 info "Removing obsolete packages"
 sudo -E "${EMERGE_CMD[@]}" --quiet --depclean @unavailable
 
-if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_TRUE}" ]]; then
+if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_FALSE}" ]]; then
   if "portageq-${BOARD}" list_preserved_libs "${BOARD_ROOT}" >/dev/null; then
     sudo -E "${EMERGE_CMD[@]}" "${REBUILD_FLAGS[@]}" @preserved-rebuild
   fi


### PR DESCRIPTION
When the --usepkgonly flag was added in d327840ce this step got wrapped
in an inverted test. It should normally be enabled.