### PR TITLE
oem/ami: write ami index files to storage after copy

### DIFF
--- a/oem/ami/prod.sh
+++ b/oem/ami/prod.sh
@@ -19,3 +19,5 @@ $DIR/copy_ami.sh -l 477645798544 ${args}
 
 source $DIR/ami-builder-us-gov-auth.sh
 $DIR/import.sh ${args}
+
+update_json.sh ${args}


### PR DESCRIPTION
Since this writes to private storage there isn't any need to wait until
the images are public to do this. Now the final publish step only
changes permissions on the AMIs and nothing more.