### PR TITLE
grub: abort boot if gptprio fails

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -107,13 +107,37 @@ fi
 # Assemble the options applicable to all the kernels below
 set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $oem_id $linux_append"
 
-menuentry "CoreOS default" --id=coreos {
-    gptprio.next -d usr -u usr_uuid
-    if [ "$usr_uuid" = "7130c94a-213a-4e5a-8e26-6cce9662f132" ]; then
-       linux$suf /coreos/vmlinuz-a @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_cmdline
-    else
-       linux$suf /coreos/vmlinuz-b @@MOUNTUSR@@=PARTUUID=$usr_uuid $linux_cmdline
+# Re-implement grub_abort() since no command exposes it.
+function abort {
+    echo
+    echo "Aborted. Press enter to exit GRUB."
+    read anything
+    exit
+}
+
+# Select the kernel and usr partition to boot.
+function gptprio {
+    # TODO: device name is no longer needed, should make it optional...
+    gptprio.next -d usr_device -u usr_uuid
+    if [ $? -ne 0 -o -z "$usr_uuid" ]; then
+        echo
+        echo "Reading or updating the GPT failed!"
+        echo "Please file a bug with any messages above to CoreOS:"
+        echo " https://github.com/coreos/bugs/issues"
+        abort
     fi
+
+    set gptprio_cmdline="@@MOUNTUSR@@=PARTUUID=$usr_uuid"
+    if [ "$usr_uuid" = "7130c94a-213a-4e5a-8e26-6cce9662f132" ]; then
+        set gptprio_kernel="/coreos/vmlinuz-a"
+    else
+        set gptprio_kernel="/coreos/vmlinuz-b"
+    fi
+}
+
+menuentry "CoreOS default" --id=coreos {
+    gptprio
+    linux$suf $gptprio_kernel $gptprio_cmdline $linux_cmdline
 }
 
 menuentry "CoreOS USR-A" --id=coreos-a {

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -39,7 +39,7 @@ GRUB_DIR="coreos/grub/${FLAGS_target}"
 GRUB_SRC="/usr/lib/grub/${FLAGS_target}"
 
 # Modules required to boot a standard CoreOS configuration
-CORE_MODULES=( normal search test fat part_gpt search_fs_uuid gzio search_part_label terminal gptprio configfile memdisk tar echo )
+CORE_MODULES=( normal search test fat part_gpt search_fs_uuid gzio search_part_label terminal gptprio configfile memdisk tar echo read )
 
 # Name of the core image, depends on target
 CORE_NAME=


### PR DESCRIPTION
If the gptprio.next command fails to give us something to boot we
shouldn't try! In order to diagnose why the failure happened halt
immediately so the user can see the error message.

For https://github.com/coreos/bugs/issues/1471