### PR TITLE
Instance store AMI support

### DIFF
--- a/oem/ami/import-instance-store.sh
+++ b/oem/ami/import-instance-store.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+#
+# This expects to run on an EC2 instance.
+
+# Set pipefail along with -e in hopes that we catch more errors
+set -e -o pipefail
+
+DIR=$(dirname $0)
+source $DIR/regions.sh
+
+readonly COREOS_EPOCH=1372636800
+VERSION="master"
+BOARD="amd64-usr"
+GROUP="alpha"
+IMAGE="coreos_production_ami_image.bin.bz2"
+GS_URL="gs://builds.release.core-os.net"
+IMG_URL=""
+IMG_PATH=""
+GRANT_LAUNCH=""
+USE_GPG=1
+# accepted via the environment
+: ${EC2_IMPORT_BUCKET:=}
+: ${EC2_IMPORT_ZONE:=}
+
+USAGE="Usage: $0 [-V 1.2.3] [-p path/image.bz2 | -u http://foo/image.bz2]
+Options:
+    -V VERSION  Set the version of this AMI, default is 'master'
+    -b BOARD    Set to the board name, default is amd64-usr
+    -g GROUP    Set the update group, default is alpha or master
+    -p PATH     Path to compressed disk image, overrides -u
+    -u URL      URL to compressed disk image, derived from -V if unset.
+    -s STORAGE  GS URL for Google storage (used to generate URL)
+    -B BUCKET   S3 bucket (or bucket/prefix) to use for storage of the AMI.
+    -Z ZONE     EC2 availability zone to use.
+    -l ACCOUNT  Grant launch permission to a given AWS account ID.
+    -c CERT     PEM-encoded X.509 certificate for EC2 API
+    -k KEY      PEM-encoded RSA key for EC2 API
+    -a ACCOUNT  Account number (without dashes) corresponding to EC2 credentials
+    -X          Disable GPG verification of downloads.
+    -h          this ;-)
+    -v          Verbose, see all the things!
+
+This script must be run from a host with the ec2-api-tools and ec2-ami-tools installed.
+"
+
+while getopts "V:b:g:p:u:s:t:l:c:k:a:B:Z:Xhv" OPTION
+do
+    case $OPTION in
+        V) VERSION="$OPTARG";;
+        b) BOARD="$OPTARG";;
+        g) GROUP="$OPTARG";;
+        p) IMG_PATH="$OPTARG";;
+        u) IMG_URL="$OPTARG";;
+        s) GS_URL="$OPTARG";;
+        B) EC2_IMPORT_BUCKET="${OPTARG}";;
+        Z) EC2_IMPORT_ZONE="${OPTARG}";;
+        l) GRANT_LAUNCH="${OPTARG}";;
+        t) export TMPDIR="$OPTARG";;
+        c) EC2_CERT_PATH="${OPTARG}";;
+        k) EC2_KEY_PATH="${OPTARG}";;
+        a) EC2_ACCOUNT="${OPTARG}";;
+        X) USE_GPG=0;;
+        h) echo "$USAGE"; exit;;
+        v) set -x;;
+        *) exit 1;;
+    esac
+done
+
+if [[ $(id -u) -eq 0 ]]; then
+    echo "$0: This command should not be ran run as root!" >&2
+    exit 1
+fi
+
+if [[ -z "${EC2_IMPORT_BUCKET}" ]]; then
+    echo "$0: -B or \$EC2_IMPORT_BUCKET must be set!" >&2
+    exit 1
+fi
+
+if [[ -z "${AWS_ACCESS_KEY}" ]]; then
+    echo "$0: \$AWS_ACCESS_KEY must be set!" >&2
+    exit 1
+fi
+if [[ -z "${AWS_SECRET_KEY}" ]]; then
+    echo "$0: \$AWS_SECRET_KEY must be set!" >&2
+    exit 1
+fi
+
+# Quick sanity check that the image exists
+if [[ -n "$IMG_PATH" ]]; then
+    if [[ ! -f "$IMG_PATH" ]]; then
+        echo "$0: Image path does not exist: $IMG_PATH" >&2
+        exit 1
+    fi
+    IMG_URL=$(basename "$IMG_PATH")
+else
+    if [[ -z "$IMG_URL" ]]; then
+        IMG_URL="$GS_URL/$GROUP/boards/$BOARD/$VERSION/$IMAGE"
+    fi
+    if [[ "$IMG_URL" == gs://* ]]; then
+        if ! gsutil -q stat "$IMG_URL"; then
+            echo "$0: Image URL unavailable: $IMG_URL" >&2
+            exit 1
+        fi
+    else
+        if ! curl --fail -s --head "$IMG_URL" >/dev/null; then
+            echo "$0: Image URL unavailable: $IMG_URL" >&2
+            exit 1
+        fi
+    fi
+fi
+
+if [[ "$VERSION" == "master" ]]; then
+    # Come up with something more descriptive and timestamped
+    TODAYS_VERSION=$(( (`date +%s` - ${COREOS_EPOCH}) / 86400 ))
+    VERSION="${TODAYS_VERSION}-$(date +%H-%M)"
+    GROUP="master"
+fi
+
+# Size of AMI file system
+# TODO: Perhaps define size and arch in a metadata file image_to_vm creates?
+size=8 # GB
+arch=x86_64
+# The name has a limited set of allowed characterrs
+name=$(sed -e "s%[^A-Za-z0-9()\\./_-]%_%g" <<< "CoreOS-$GROUP-$VERSION")
+description="CoreOS $GROUP $VERSION"
+
+if [[ -z "${EC2_IMPORT_ZONE}" ]]; then
+    zoneurl=http://instance-data/latest/meta-data/placement/availability-zone
+    EC2_IMPORT_ZONE=$(curl --fail -s $zoneurl)
+fi
+region=$(echo "${EC2_IMPORT_ZONE}" | sed 's/.$//')
+akiid=${ALL_AKIS[$region]}
+ec2manifestcert=${EC2_MANIFEST_CERT_PATH[$region]}
+
+if [ -z "$akiid" ]; then
+   echo "$0: Can't identify AKI, using region: $region" >&2
+   exit 1
+fi
+
+if [ -z "$ec2manifestcert" ]; then
+   echo "$0: Can't identify EC2 manifest encryption certificate, using region: $region" >&2
+   exit 1
+fi
+
+export EC2_URL="https://ec2.${region}.amazonaws.com"
+echo "Building AMI in zone ${EC2_IMPORT_ZONE}"
+
+tmpdir=$(mktemp --directory --tmpdir=/var/tmp)
+trap "rm -rf '${tmpdir}'" EXIT
+
+# if it is on the local fs, just use it, otherwise try to download it
+if [[ -z "$IMG_PATH" ]]; then
+    IMG_PATH="${tmpdir}/${IMG_URL##*/}"
+    if [[ "$IMG_URL" == gs://* ]]; then
+        gsutil cp "$IMG_URL" "$IMG_PATH"
+        if [[ "$USE_GPG" != 0 ]]; then
+            gsutil cp "${IMG_URL}.sig" "${IMG_PATH}.sig"
+        fi
+    else
+        curl --fail "$IMG_URL" > "$IMG_PATH"
+        if [[ "$USE_GPG" != 0 ]]; then
+            curl --fail "${IMG_URL}.sig" > "${IMG_PATH}.sig"
+        fi
+    fi
+fi
+
+if [[ "$USE_GPG" != 0 ]]; then
+    gpg --verify "${IMG_PATH}.sig"
+fi
+
+echo "Bunzipping...."
+tmpimg="${tmpdir}/img"
+bunzip2 -c "$IMG_PATH" >"${tmpimg}"
+
+imgfmt=ponies
+case "$IMG_PATH" in
+    *_image.bin*)  imgfmt=raw;;
+    *_image.vmdk*) imgfmt=vmdk;;
+    *_image.vhd*)  imgfmt=vhd;;
+    *)
+        echo "$0: Cannot guess image format from image path!"
+        exit 1
+        ;;
+esac
+
+# TODO: Can we convert VMDK/VHDs to raw?
+if [[ "$imgfmt" != "raw" ]]; then
+    echo "$0: image must be in raw format"
+    exit 1
+fi
+
+# Bundle the image, converting it from a raw image to a bunch of files and generating a manifest
+bundledir="${tmpdir}/bundle"
+mkdir "${bundledir}"
+ec2-bundle-image --cert "${EC2_CERT_PATH}" --privatekey "${EC2_KEY_PATH}" --user "${EC2_ACCOUNT}" \
+  --image "${tmpimg}" \
+  --destination "${bundledir}" \
+  --ec2cert "$ec2manifestcert" \
+  --arch "$arch" \
+  --block-device-mapping ami=sda,root=/dev/sda,ephemeral0=sdb \
+  --prefix "${name}"
+
+# Upload the bundle
+ec2-upload-bundle \
+  --bucket "${EC2_IMPORT_BUCKET}/${name}/" \
+  --access-key "${AWS_ACCESS_KEY}" \
+  --secret-key "${AWS_SECRET_KEY}" \
+  --directory "${bundledir}" \
+  --manifest "${bundledir}/${name}.manifest.xml" \
+  --retry  
+
+# Having uploaded the bundle, we can now register some AMIs
+echo "Registering hvm AMI"
+hvm_amiid=$(ec2-register                              \
+  "${EC2_IMPORT_BUCKET}/${name}/${name}.manifest.xml" \
+  --name "${name}-is-hvm"                             \
+  --description "$description (instance-store HVM)"   \
+  --architecture "$arch"                              \
+  --virtualization-type hvm                           \
+  --root-device-name /dev/sda                         \
+  --sriov simple                                      |
+  cut -f2)
+
+echo "Registering paravirtual AMI"
+pv_amiid=$(ec2-register                               \
+  "${EC2_IMPORT_BUCKET}/${name}/${name}.manifest.xml" \
+  --name "${name}-is-pv"                              \
+  --description "$description (instance-store PV)"    \
+  --architecture "$arch"                              \
+  --virtualization-type paravirtual                   \
+  --kernel "$akiid"                                   \
+  --root-device-name /dev/sda                         \
+  --sriov simple                                      |
+  cut -f2)
+
+if [[ -n "${GRANT_LAUNCH}" ]]; then
+  echo "Granting launch permission to ${GRANT_LAUNCH}"
+  ec2-modify-image-attribute "${hvm_amiid}" \
+      --launch-permission --add "${GRANT_LAUNCH}"
+  ec2-modify-image-attribute "${pv_amiid}" \
+      --launch-permission --add "${GRANT_LAUNCH}"
+fi
+
+cat <<EOF
+$description
+architecture: $arch
+region:       $region (${EC2_IMPORT_ZONE})
+aki id:       $akiid
+name:         $name
+description:  $description
+PV AMI id:    $pv_amiid
+HVM AMI id:   $hvm_amiid
+EOF

--- a/oem/ami/regions.sh
+++ b/oem/ami/regions.sh
@@ -20,3 +20,13 @@ MAIN_REGIONS=( "${!ALL_AKIS[@]}" )
 ALL_AKIS["us-gov-west-1"]=aki-1de98d3e
 
 ALL_REGIONS=( "${!ALL_AKIS[@]}" )
+
+# One other region-specific detail:
+#   http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/CLTRG-ami-bundle-image.html
+# The us-gov-west-1 and cn-north-1 regions use a non-default public key certificate and the path to that certificate must be specified with this option.
+declare -A EC2_MANIFEST_CERT_PATH
+for region in ${!ALL_AKIS[@]}; do
+  EC2_MANIFEST_CERT_PATH[$region]=$EC2_AMITOOL_HOME/etc/ec2/amitools/cert-ec2.pem
+done
+EC2_MANIFEST_CERT_PATH["us-gov-west-1"]=$EC2_AMITOOL_HOME/etc/ec2/amitools/cert-ec2-gov.pem
+EC2_MANIFEST_CERT_PATH["cn-north-1"]=$EC2_AMITOOL_HOME/etc/ec2/amitools/cert-ec2-cn-north-1.pem


### PR DESCRIPTION
This PR adds support for creating instance store AMIs (coreos/bugs#177).

`oem/ami/import.sh` has a lot going on, but ultimately it:
- Builds lots of state
- Downloads an image (probably)
- Produces an uncompressed, authenticated `coreos_production_ami_image.bin` file
- Uses `ec2-import-volume` to turn the image file into an EBS volume
- Uses `ec2-create-snapshot` to turn that EBS volume into an EBS snapshot
- Registers an HVM AMI based on that snapshot
- Registers a PV AMI based on that snapshot

`oem/ami/import-instance-store.sh` is based on `oem/ami/import.sh` since it shares much of this process. This new script:
- Builds lots of state
- Downloads an image (probably)
- Produces an uncompressed, authenticated `coreos_production_ami_image.bin` file
- Uses [`ec2-bundle-image`](http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/CLTRG-ami-bundle-image.html) to turn the image into a bunch of smaller files and a corresponding manifest
- Uses [`ec2-upload-bundle`](http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/CLTRG-ami-upload-bundle.html) to copy the bundle files to S3
- Registers an HVM AMI based on that bundle
- Registers a PV AMI based on that bundle

I think it makes sense to produce instance store AMIs alongside the EBS AMIs, in which case the `ec2-bundle-image` + `ec2-upload-bundle` steps should be merged into `oem/ami/import.sh` such that it produces 4 AMIs instead of 2. This PR keeps them separate so the instance store AMI generation process can be discussed and executed in isolation.

`coreos_production_ami_image.bin` appears to work as an instance store AMI without modification. My setup process was:
1. Launch an Amazon Linux instance.
2. Copy scripts
3. Copy [EC2 X.509 certificate + key](http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ec2-cli-managing-certs.html), since instance store AMI creation additionally requires these credentials

Then, to create the AMIs:

```
$ export AWS_ACCESS_KEY_ID=AKI…
$ export AWS_SECRET_ACCESS_KEY=…
$ export AWS_ACCESS_KEY=$AWS_ACCESS_KEY_ID
$ export AWS_SECRET_KEY=$AWS_SECRET_ACCESS_KEY
$ VERSION=1068.8.0
$ oem/ami/import-instance-store.sh -V $VERSION -g stable -u http://stable.release.core-os.net/amd64-usr/$VERSION/coreos_production_ami_image.bin.bz2 -B totally-not-official-ami -c /home/ec2-user/secrets/cert.pem -k /home/ec2-user/secrets/pk.pem -a <123456789012> -X
Building AMI in zone us-east-1e
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  255M  100  255M    0     0   122M      0  0:00:02  0:00:02 --:--:--  122M
Bunzipping....
Bundling image file...
…
Manifest uploaded to: totally-not-official-ami/CoreOS-stable-1068.8.0/CoreOS-stable-1068.8.0.manifest.xml
Bundle upload completed.
Registering hvm AMI
Registering paravirtual AMI
CoreOS stable 1068.8.0
architecture: x86_64
region:       us-east-1 (us-east-1e)
aki id:       aki-919dcaf8
name:         CoreOS-stable-1068.8.0
description:  CoreOS stable 1068.8.0
PV AMI id:    ami-2881143f
HVM AMI id:   ami-f58613e2
```

Full output is recorded for posterity in [this gist](https://gist.github.com/willglynn/b6732508d8a4ed1f69bf0dc5ed1c9a40).

The AMIs `ami-2881143f` and `ami-f58613e2` are public for the purposes of this PR. (In other words, don't use them in production because I will delete them at some point.) Both AMIs appear to work:

```
$ aws ec2 run-instances --image-id ami-2881143f --key-name … --subnet-id … --security-group-ids … --instance-type m3.large
$ aws ec2 run-instances --image-id ami-f58613e2 --key-name … --subnet-id … --security-group-ids … --instance-type m3.large
```

My goal is to get official CoreOS instance store AMIs, created and published by the usual official process. How do we get there from here?
