### PR TITLE
Force HTTP/1.0 in fix_check_etag.sh

### DIFF
--- a/oem/generic/check_etag.sh
+++ b/oem/generic/check_etag.sh
@@ -2,14 +2,14 @@
 # check_etag.sh
 #
 # A tool for monitoring remote files and acting if the file has changed
-# This tool has been optimized for use on CoreOS but should work 
+# This tool has been optimized for use on CoreOS but should work
 # for most files where an ETag is exposed.
- 
+
 # by default we retrieve the alpha image, set to  a different value to retrieve
 # that release
 
 set -e -o pipefail
- 
+
 # Set default release to alpha if not specified
 release=${1:-"alpha"}
 
@@ -21,7 +21,7 @@ else
   release=$(echo ${url} | sed -e 's/http:\/\///1' -e 's/\//-/g' )
 fi
 tmplocation="/tmp/etagsync"
- 
+
 # Create location for storage of CoreOS image state
 mkdir -p ${tmplocation}
 pushd ${tmplocation} > /dev/null 2>&1
@@ -32,11 +32,11 @@ if [ ! -f ${release}_etag ]; then
 fi
 
 # Retrieve the remote etag header
-remote_etag=$(curl -I ${url} -k -s  | \
-  gawk '/ETag/ {print gensub("\"", "", "g", $2)}')
- 
+remote_etag=$(curl -I ${url} -k -s | \
+  grep -i '^etag:' | sed -e 's/.*: *//' -e 's/["\r\n]//g')
+
 source ${release}_etag > /dev/null 2>&1
- 
+
 if [ "$remote_etag" == "$local_etag" ]; then
   echo "Everything is current"
   exit 0


### PR DESCRIPTION
Curl and CloudFlare now support HTTP/2. While that's great news, it breaks `fix_check_etag.sh` because headers are lower-case in h2.

Forcing HTTP/1.0 has good backwards compatibility with Curl, no significant performance impact and resolves the inconsistency.