### PR TITLE
catalyst: workaround for bootstrap_sdk on Ubuntu

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -78,6 +78,7 @@ export EMERGE_DEFAULT_OPTS="\$MAKEOPTS"
 export PORTAGE_USERNAME=portage
 export PORTAGE_GRPNAME=portage
 export GENTOO_MIRRORS='$(portageq envvar GENTOO_MIRRORS)'
+export ac_cv_posix_semaphores_enabled=yes
 EOF
 }
 


### PR DESCRIPTION
workaround for bootstrap_sdk on an Ubuntu host where /dev/shm is a
symlink to /run/shm. Since we mount the hosts /dev (for losetup) this
interferes with building python 2.7. The workaround is to disable the
/dev/shm during python builds. A longer term fix would be to not mount
the hosts /dev. Thanks for marineam for suggesting the fix on IRC.