### PR TITLE
grub: rename oem_id variable

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -72,8 +72,9 @@ if [ -n "$first_boot" ]; then
     set first_boot="coreos.first_boot=1 coreos.randomize_disk_guid=00000000-0000-0000-0000-000000000001"
 fi
 
+set oem=""
 if [ -n "$oem_id" ]; then
-    set oem_id="coreos.oem.id=$oem_id"
+    set oem="coreos.oem.id=$oem_id"
 fi
 
 # If no specific console has been set by the OEM then select based on
@@ -105,7 +106,7 @@ if [ "$grub_platform" = efi ]; then
 fi
 
 # Assemble the options applicable to all the kernels below
-set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $oem_id $linux_append"
+set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $oem $linux_append"
 
 # Re-implement grub_abort() since no command exposes it.
 function abort {


### PR DESCRIPTION
On HVM instances, tty0 is actually a graphical interface. Since the
interface exposed is non-interactive, it's not possible to scroll
through the logs, which results in lots of missing information. Setting
the console to ttyS0, on the other hand, sends the output to the system
log.

PV instances don't have this issue since they are xen-based and use
hvc0.