### PR TITLE
build_image: generate C.UTF-8 locale

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -97,6 +97,7 @@ create_dev_image() {
   set_image_profile dev
   emerge_to_image "${root_fs_dir}" @system ${base_pkg}
   run_ldconfig "${root_fs_dir}"
+  run_localedef "${root_fs_dir}"
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
   write_licenses "${root_fs_dir}" "${BUILD_DIR}/${image_licenses}"
 

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -76,6 +76,7 @@ create_prod_image() {
   extract_prod_gcc "${root_fs_dir}"
   emerge_to_image "${root_fs_dir}" "${base_pkg}"
   run_ldconfig "${root_fs_dir}"
+  run_localedef "${root_fs_dir}"
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
   write_licenses "${root_fs_dir}" "${BUILD_DIR}/${image_licenses}"
   extract_docs "${root_fs_dir}"
@@ -112,6 +113,9 @@ EOF
   sudo mkdir -p ${root_fs_dir}/usr/lib/pam.d
   sudo mv -n ${root_fs_dir}/etc/pam.d/* ${root_fs_dir}/usr/lib/pam.d/
   sudo rmdir ${root_fs_dir}/etc/pam.d
+
+  # Remove source locale data, only need to ship the compiled archive.
+  sudo rm -rf ${root_fs_dir}/usr/share/i18n/
 
   finish_image \
       "${image_name}" \


### PR DESCRIPTION
Depends on https://github.com/coreos/coreos-overlay/pull/2213
Fixes https://github.com/coreos/bugs/issues/112

I'm not sure if it is truely required to run the target's localedef or if the format is independent enough to just use the hosts. To play it safe I'm using the target's similar to how we handle ldconfig.