### PR TITLE
build_image: disable verity again for 1192

### DIFF
--- a/build_image
+++ b/build_image
@@ -28,6 +28,8 @@ DEFINE_string getbinpkgver "" \
   "Use binary packages from a specific version."
 DEFINE_boolean enable_rootfs_verification ${FLAGS_TRUE} \
   "Default all bootloaders to use kernel-based root fs integrity checking."
+DEFINE_boolean enable_verity ${FLAGS_FALSE} \
+  "Default GRUB to use dm-verity-enabled boot arguments"
 DEFINE_string base_pkg "coreos-base/coreos" \
   "The base portage package to base the build off of (only applies to prod images)"
 DEFINE_string base_dev_pkg "coreos-base/coreos-dev" \

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -393,7 +393,7 @@ finish_image() {
       target_list="arm64-efi"
     fi
     for target in ${target_list}; do
-      if [[ ${disable_read_write} -eq ${FLAGS_TRUE} ]]; then
+      if [[ ${disable_read_write} -eq ${FLAGS_TRUE} && ${FLAGS_enable_verity} -eq ${FLAGS_TRUE} ]]; then
         ${BUILD_LIBRARY_DIR}/grub_install.sh \
             --board="${BOARD}" \
             --target="${target}" \

--- a/build_library/generate_grub_hashes.py
+++ b/build_library/generate_grub_hashes.py
@@ -40,7 +40,7 @@ with open(os.path.join(outputdir, "grub_modules.config"), "w") as f:
     f.write(json.dumps({"9": {"binaryvalues": [{"prefix": "grub_module", "values": hashvalues}]}}))
 
 with open(os.path.join(outputdir, "kernel_cmdline.config"), "w") as f:
-    f.write(json.dumps({"8": {"asciivalues": [{"prefix": "grub_kernel_cmdline", "values": [{"value": "rootflags=rw mount.usrflags=ro BOOT_IMAGE=/coreos/vmlinuz-[ab] mount.usr=/dev/mapper/usr verity.usr=PARTUUID=\S{36} rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (coreos.autologin=\S+)? verity.usrhash=\\S{64}", "description": "CoreOS kernel command line %s" % version}]}]}}))
+    f.write(json.dumps({"8": {"asciivalues": [{"prefix": "grub_kernel_cmdline", "values": [{"value": "rootflags=rw mount.usrflags=ro BOOT_IMAGE=/coreos/vmlinuz-[ab] mount.usr=PARTUUID=\S{36} rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (coreos.autologin=\S+)? verity.usrhash=\\S{64}", "description": "CoreOS kernel command line %s" % version}]}]}}))
 
 commands = [{"value": '\[.*\]', "description": "CoreOS Grub configuration %s" % version},
             {"value": 'gptprio.next -d usr -u usr_uuid', "description": "CoreOS Grub configuration %s" % version},


### PR DESCRIPTION
The Xen loader in GRUB never received support for our hacky scheme of
adding the verity hash to the kernel cmdline. Disable till that's fixed.

Partially reverts 2016567 and 533b1b9.