### PR TITLE
build_jobs: split minimal prefix out of job scripts

### DIFF
--- a/build_jobs/02_sdk.sh
+++ b/build_jobs/02_sdk.sh
@@ -34,20 +34,12 @@
 
 set -ex
 
-# build may not be started without a ref value
-[[ -n "${MANIFEST_REF#refs/tags/}" ]]
-
 enter() {
   ./bin/cork enter --experimental -- "$@"
 }
 
 # hack because catalyst leaves things chowned as root
 [[ -d .cache/sdks ]] && sudo chown -R $USER .cache/sdks
-
-./bin/cork update --create --downgrade-replace --verify --verbose \
-                  --manifest-url "${MANIFEST_URL}" \
-                  --manifest-branch "${MANIFEST_REF}" \
-                  --manifest-name "${MANIFEST_NAME}"
 
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID

--- a/build_jobs/02_toolchains.sh
+++ b/build_jobs/02_toolchains.sh
@@ -34,20 +34,9 @@
 
 set -ex
 
-# build may not be started without a ref value
-[[ -n "${MANIFEST_REF#refs/tags/}" ]]
-
 enter() {
   ./bin/cork enter --experimental -- "$@"
 }
-
-# hack because catalyst leaves things chowned as root
-[[ -d .cache/sdks ]] && sudo chown -R $USER .cache/sdks
-
-./bin/cork update --create --downgrade-replace --verify --verbose \
-                  --manifest-url "${MANIFEST_URL}" \
-                  --manifest-branch "${MANIFEST_REF}" \
-                  --manifest-name "${MANIFEST_NAME}"
 
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID

--- a/build_jobs/03_packages.sh
+++ b/build_jobs/03_packages.sh
@@ -30,9 +30,6 @@
 
 set -ex
 
-# build may not be started without a ref value
-[[ -n "${MANIFEST_REF#refs/tags/}" ]]
-
 # use a ccache dir that persists across sdk recreations
 # XXX: alternatively use a ccache dir that is usable by all jobs on a given node.
 mkdir -p .cache/ccache
@@ -47,12 +44,6 @@ script() {
   local script="/mnt/host/source/src/scripts/${1}"; shift
   enter "${script}" "$@"
 }
-
-./bin/cork update --create --downgrade-replace --verify --verbose \
-                  --manifest-url "${MANIFEST_URL}" \
-                  --manifest-branch "${MANIFEST_REF}" \
-                  --manifest-name "${MANIFEST_NAME}" \
-                  -- --toolchain_boards=${BOARD}
 
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID

--- a/build_jobs/04_images.sh
+++ b/build_jobs/04_images.sh
@@ -38,9 +38,6 @@
 
 set -ex
 
-# build may not be started without a ref value
-[[ -n "${MANIFEST_REF#refs/tags/}" ]]
-
 # first thing, clear out old images
 sudo rm -rf src/build
 
@@ -48,11 +45,6 @@ script() {
   local script="/mnt/host/source/src/scripts/${1}"; shift
   ./bin/cork enter --experimental -- "${script}" "$@"
 }
-
-./bin/cork update --create --downgrade-replace --verify --verbose \
-                  --manifest-url "${MANIFEST_URL}" \
-                  --manifest-branch "${MANIFEST_REF}" \
-                  --manifest-name "${MANIFEST_NAME}"
 
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID

--- a/build_jobs/05_vm.sh
+++ b/build_jobs/05_vm.sh
@@ -48,9 +48,6 @@ set -ex
 rm -f gce.properties
 sudo rm -rf tmp
 
-# build may not be started without a ref value
-[[ -n "${MANIFEST_REF#refs/tags/}" ]]
-
 # check that the matrix didn't go bananas
 if [[ "${COREOS_OFFICIAL}" -eq 1 ]]; then
   [[ "${GROUP}" != developer ]]
@@ -66,11 +63,6 @@ script() {
 enter() {
   ./bin/cork enter --experimental -- "$@"
 }
-
-./bin/cork update --create --downgrade-replace --verify --verbose \
-                  --manifest-url "${MANIFEST_URL}" \
-                  --manifest-branch "${MANIFEST_REF}" \
-                  --manifest-name "${MANIFEST_NAME}"
 
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID

--- a/build_jobs/stub.sh
+++ b/build_jobs/stub.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This is the common job code to paste into Jenkins for everything except
+# the manifest job. Update the exec line as appropriate.
+
+set -ex
+
+# build may not be started without a ref value
+[[ -n "${MANIFEST_REF#refs/tags/}" ]]
+
+# hack for catalyst jobs which may leave things chowned as root
+#[[ -d .cache/sdks ]] && sudo chown -R $USER .cache/sdks
+
+./bin/cork update --create --downgrade-replace --verify --verbose \
+                  --manifest-url "${MANIFEST_URL}" \
+                  --manifest-branch "${MANIFEST_REF}" \
+                  --manifest-name "${MANIFEST_NAME}"
+# add to packages job args which needs a full toolchain:
+#                  -- --toolchain_boards=${BOARD}
+
+exec ./src/scripts/build_jobs/00_job.sh


### PR DESCRIPTION
The chroot update/creation step must live in Jenkins but after that the
jobs can use these scripts. A template is provided in stub.sh