### PR TITLE
build_jobs: drop old hack for 1010 branch

### DIFF
--- a/build_jobs/03_packages.sh
+++ b/build_jobs/03_packages.sh
@@ -48,11 +48,6 @@ script() {
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID
 
-if [[ "${COREOS_VERSION}" == 1010.* && "${BOARD}" == arm64-usr ]]; then
-  echo "SKIPPING ARM"
-  exit 0
-fi
-
 # figure out if ccache is doing us any good in this scheme
 enter ccache --zero-stats
 

--- a/build_jobs/04_images.sh
+++ b/build_jobs/04_images.sh
@@ -49,11 +49,6 @@ script() {
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID
 
-if [[ "${COREOS_VERSION}" == 1010.* && "${BOARD}" == arm64-usr ]]; then
-  echo "SKIPPING ARM"
-  exit 0
-fi
-
 # Set up GPG for signing images
 export GNUPGHOME="${PWD}/.gnupg"
 rm -rf "${GNUPGHOME}"

--- a/build_jobs/05_vm.sh
+++ b/build_jobs/05_vm.sh
@@ -67,11 +67,6 @@ enter() {
 source .repo/manifests/version.txt
 export COREOS_BUILD_ID
 
-if [[ "${COREOS_VERSION}" == 1010.* && "${BOARD}" == arm64-usr ]]; then
-  echo "SKIPPING ARM"
-  exit 0
-fi
-
 # Set up GPG for signing images
 export GNUPGHOME="${PWD}/.gnupg"
 rm -rf "${GNUPGHOME}"


### PR DESCRIPTION
Not applicable to these scripts which do not build branches other than
their own. Plus the 1010 branch is dead now anyway.