### PR TITLE
grub.cfg: Enable arm64 ACPI

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -96,6 +96,11 @@ if [ -z "$linux_console" ]; then
     fi
 fi
 
+set extra_options=""
+if [ "$grub_cpu" = arm64 ]; then
+	set extra_options="acpi=force"
+fi
+
 set suf=""
 
 # UEFI uses linuxefi/initrdefi instead of linux/initrd except for arm64
@@ -106,7 +111,7 @@ if [ "$grub_platform" = efi ]; then
 fi
 
 # Assemble the options applicable to all the kernels below
-set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $oem $linux_append"
+set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $extra_options $oem $linux_append"
 
 # Re-implement grub_abort() since no command exposes it.
 function abort {


### PR DESCRIPTION
By default, ACPI is disabled on arm64 even if support is built in to the kernel (```CONFIG_ACPI=y```).

This change adds a new grub.cnf variable ```platform_options``` and sets ```acpi=force``` to enable ACPI on arm64 platforms.

Needs https://github.com/coreos/coreos-overlay/pull/2273 (arm64_defconfig: Enable ACPI).