### PR TITLE
scripts: Add arm64 verity support

### DIFF
--- a/build_image
+++ b/build_image
@@ -86,11 +86,6 @@ switch_to_strict_mode
 
 check_gsutil_opts
 
-# Inserting the verity hash into the kernel assumes x86_64
-if [[ "${FLAGS_board}" != amd64-usr ]]; then
-  FLAGS_enable_rootfs_verification=${FLAGS_FALSE}
-fi
-
 # If downloading packages is enabled ensure the board is configured properly.
 if [[ ${FLAGS_getbinpkg} -eq ${FLAGS_TRUE} ]]; then
   "${SRC_ROOT}/scripts/setup_board" --board="${FLAGS_board}" \

--- a/build_image
+++ b/build_image
@@ -28,8 +28,6 @@ DEFINE_string getbinpkgver "" \
   "Use binary packages from a specific version."
 DEFINE_boolean enable_rootfs_verification ${FLAGS_TRUE} \
   "Default all bootloaders to use kernel-based root fs integrity checking."
-DEFINE_boolean enable_verity ${FLAGS_TRUE} \
-  "Default GRUB to use dm-verity-enabled boot arguments"
 DEFINE_string base_pkg "coreos-base/coreos" \
   "The base portage package to base the build off of (only applies to prod images)"
 DEFINE_string base_dev_pkg "coreos-base/coreos-dev" \

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -304,7 +304,13 @@ finish_image() {
   local install_grub=0
   local disk_img="${BUILD_DIR}/${image_name}"
 
+  # Only enable rootfs verification on prod builds.
   if [[ "${IMAGE_BUILD_TYPE}" != "prod" ]]; then
+    FLAGS_enable_rootfs_verification=${FLAGS_FALSE}
+  fi
+
+  # Only enable rootfs verification on supported boards.
+  if [[ "${FLAGS_board}" != amd64-usr ]]; then
     FLAGS_enable_rootfs_verification=${FLAGS_FALSE}
   fi
 

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -304,9 +304,8 @@ finish_image() {
   local install_grub=0
   local disk_img="${BUILD_DIR}/${image_name}"
 
-  local disable_read_write="${FLAGS_FALSE}"
-  if [[ "${IMAGE_BUILD_TYPE}" == "prod" ]]; then
-    disable_read_write="${FLAGS_enable_rootfs_verification}"
+  if [[ "${IMAGE_BUILD_TYPE}" != "prod" ]]; then
+    FLAGS_enable_rootfs_verification=${FLAGS_FALSE}
   fi
 
   # Copy kernel to support dm-verity boots
@@ -355,7 +354,7 @@ finish_image() {
   fi
 
   # Make the filesystem un-mountable as read-write and setup verity.
-  if [[ ${disable_read_write} -eq ${FLAGS_TRUE} ]]; then
+  if [[ ${FLAGS_enable_rootfs_verification} -eq ${FLAGS_TRUE} ]]; then
     # Unmount /usr partition
     sudo umount --recursive "${root_fs_dir}/usr" || exit 1
 
@@ -405,7 +404,7 @@ finish_image() {
       target_list="arm64-efi"
     fi
     for target in ${target_list}; do
-      if [[ ${disable_read_write} -eq ${FLAGS_TRUE} && ${FLAGS_enable_verity} -eq ${FLAGS_TRUE} ]]; then
+      if [[ ${FLAGS_enable_rootfs_verification} -eq ${FLAGS_TRUE} && ${FLAGS_enable_verity} -eq ${FLAGS_TRUE} ]]; then
         ${BUILD_LIBRARY_DIR}/grub_install.sh \
             --board="${BOARD}" \
             --target="${target}" \

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -404,7 +404,7 @@ finish_image() {
       target_list="arm64-efi"
     fi
     for target in ${target_list}; do
-      if [[ ${FLAGS_enable_rootfs_verification} -eq ${FLAGS_TRUE} && ${FLAGS_enable_verity} -eq ${FLAGS_TRUE} ]]; then
+      if [[ ${FLAGS_enable_rootfs_verification} -eq ${FLAGS_TRUE} ]]; then
         ${BUILD_LIBRARY_DIR}/grub_install.sh \
             --board="${BOARD}" \
             --target="${target}" \


### PR DESCRIPTION
Tested with amd64 coreos_production_qemu_uefi and did not see any regressions.

Depends on:
https://github.com/coreos/grub/pull/42 "Add arm64 verity support" 
coreos/coreos-overlay#2277 "coreos-sources: Add arm64 verity hash"

cc: @mjg59 
