### PR TITLE
build_image: specify arguments more clearly

### DIFF
--- a/build_image
+++ b/build_image
@@ -60,7 +60,7 @@ container - Developer image with single filesystem, bootable by nspawn.
 
 Examples:
 
-build_image --board=<board> dev prod - builds developer and production images.
+build_image --board=<board> [dev] [prod] [container] - builds developer and production images.
 ...
 "
 show_help_if_requested "$@"


### PR DESCRIPTION
Technically it's "one of dev, prod, or container". I think this makes that slightly clearer. (edit: actually, multiple are okay too!)