### PR TITLE
build_library: pass force_size when converting disks to vpc

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -533,7 +533,7 @@ _write_qcow2_disk() {
 }
 
 _write_vhd_disk() {
-    qemu-img convert -f raw "$1" -O vpc "$2"
+    qemu-img convert -f raw "$1" -O vpc -o force_size "$2"
     assert_image_size "$2" vpc
 }
 


### PR DESCRIPTION
this stops qemu-img info from choking on vpc-type images made with our
patched qemu.