### PR TITLE
check_root: ignore scripts in documentation

### DIFF
--- a/build_library/check_root
+++ b/build_library/check_root
@@ -80,6 +80,8 @@ IGNORE_SHEBANG = (
     b"*/usr/lib64/modules/*/source/scripts/*",
     b"*/usr/share/nova-agent/*/etc/gentoo/nova-agent",
     b"*/tmp/*",
+    b"*/Documentation/*",
+    b"*/doc/*",
 )
 
 def provided_sonames():


### PR DESCRIPTION
Treating documentation files as not really having dependencies is normal among other distros.  By ignoring script headers in documentation files, we'll drop a few of our own warnings.