### PR TITLE
disk_util: differentiate between partition and FS labels

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -11,6 +11,7 @@
     "base":{
       "1":{
         "label":"EFI-SYSTEM",
+        "fs_label":"EFI-SYSTEM",
         "type":"efi",
         "blocks":"262144",
         "fs_type":"vfat",
@@ -47,6 +48,7 @@
       },
       "6":{
         "label":"OEM",
+        "fs_label":"OEM",
         "type":"data",
         "blocks":"262144",
         "fs_type":"ext4",
@@ -64,6 +66,7 @@
       },
       "9":{
         "label":"ROOT",
+        "fs_label":"ROOT",
         "type":"coreos-resize",
         "blocks":"4427776",
         "fs_type":"ext4",
@@ -75,8 +78,8 @@
         "label":"USR-A",
         "uuid":"7130c94a-213a-4e5a-8e26-6cce9662f132",
         "type":"coreos-rootfs",
-	"blocks":"4194304",
-	"fs_blocks":"520188",
+        "blocks":"4194304",
+        "fs_blocks":"520188",
         "fs_type":"ext2",
         "mount":"/usr",
         "features": ["prioritize", "verity"]
@@ -85,35 +88,40 @@
         "label":"USR-B",
         "uuid":"e03dd35c-7c2d-4a47-b3fe-27f15780a57c",
         "type":"coreos-rootfs",
-	"blocks":"4194304",
-	"fs_blocks":"520188"
+        "blocks":"4194304",
+        "fs_blocks":"520188"
       },
       "9":{
         "label":"ROOT",
+        "fs_label":"ROOT",
         "blocks":"12943360"
       }
     },
     "vm":{
       "9":{
         "label":"ROOT",
+        "fs_label":"ROOT",
         "blocks":"12943360"
       }
     },
     "azure":{
       "9":{
         "label":"ROOT",
+        "fs_label":"ROOT",
         "blocks":"58875904"
       }
     },
     "vagrant":{
       "9":{
         "label":"ROOT",
+        "fs_label":"ROOT",
         "blocks":"33845248"
       }
     },
     "onmetal":{
       "7":{
         "label":"config-2",
+        "fs_label":"config-2",
         "type":"data",
         "fs_type":"ext2"
       }
@@ -145,6 +153,7 @@
       },
       "9":{
         "label":"ROOT",
+        "fs_label":"ROOT",
         "type":"4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
         "blocks":"6291456"
       }
@@ -152,6 +161,7 @@
     "secure_demo":{
       "1":{
         "label":"EFI-SYSTEM",
+        "fs_label":"EFI-SYSTEM",
         "type":"efi",
         "blocks":"2097152",
         "fs_type":"vfat",
@@ -186,6 +196,7 @@
     "interoute":{
       "9":{
         "label":"ROOT",
+        "fs_label":"ROOT",
         "blocks":"33845248"
       }
     }

--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -45,7 +45,7 @@ def LoadPartitionConfig(options):
   valid_layout_keys = set((
       '_comment', 'type', 'num', 'label', 'blocks', 'block_size', 'fs_blocks',
       'fs_block_size', 'fs_type', 'features', 'uuid', 'part_alignment', 'mount',
-      'binds', 'fs_subvolume', 'fs_bytes_per_inode', 'fs_inode_size'))
+      'binds', 'fs_subvolume', 'fs_bytes_per_inode', 'fs_inode_size', 'fs_label'))
   integer_layout_keys = set((
       'blocks', 'block_size', 'fs_blocks', 'fs_block_size', 'part_alignment',
       'fs_bytes_per_inode', 'fs_inode_size'))
@@ -388,9 +388,10 @@ def FormatBtrfs(part, device):
     part: dict defining the partition
     device: name of the block device to format
   """
-  Sudo(['mkfs.btrfs', '--byte-count', part['fs_bytes'],
-                      '--label', part['label'],
-                      device])
+  cmd = ['mkfs.btrfs', '--byte-count', part['fs_bytes']]
+  if 'fs_label' in part:
+    cmd += ['--label', part['fs_label']]
+  Sudo(cmd + [device])
 
   if part.get('fs_subvolume', None):
     btrfs_mount = tempfile.mkdtemp()
@@ -420,7 +421,10 @@ def FormatExt(part, device):
                   device,
                   part['fs_blocks']])
 
-  tune_cmd = ['tune2fs', '-L', part['label'], '-e', 'remount-ro']
+  tune_cmd = ['tune2fs', '-e', 'remount-ro']
+
+  if 'fs_label' in part:
+    tune_cmd += ['-L', part['fs_label']]
 
   if part['type'] == 'coreos-usr':
     tune_cmd += ['-U', 'clear',
@@ -442,10 +446,10 @@ def FormatFat(part, device):
   vfat_block_size = 1024
   vfat_blocks = part['bytes'] // vfat_block_size
 
-  Sudo(['mkfs.vfat', '-n', part['label'],
-                     device,
-                     vfat_blocks],
-                     stdout_null=True)
+  cmd = ['mkfs.vfat']
+  if 'fs_label' in part:
+    cmd += ['-n', part['fs_label']]
+  Sudo(cmd + [device, vfat_blocks], stdout_null=True)
 
   if 'syslinux' in part.get('features', []):
     # Install using extlinux so we can operate on the mounted filesystem and


### PR DESCRIPTION
I've left file system labels off everything except ROOT, OEM, EFI-SYSTEM, and config-2.

This fixes coreos/bugs#1628.