### PR TITLE
Set ovf transport mode so guestinfo gets available to coreos-cloudinit

### DIFF
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -87,7 +87,7 @@
     <OperatingSystemSection ovf:id="100" vmw:osType="other26xLinux64Guest">
       <Info>The kind of installed guest operating system</Info>
     </OperatingSystemSection>
-    <VirtualHardwareSection>
+    <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">
       <Info>Virtual hardware requirements</Info>
       <System>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>


### PR DESCRIPTION
Without setting ovf:transport attribute to com.vmware.guestInfo in the VirtualHardwareSection, coreos-cloudinit returns empty values. VM Hardware version 7.

