### PR TITLE
build_image: Extract and upload GRUB/shim EFI images for signing

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -22,6 +22,10 @@ DEFINE_string disk_image "" \
   "The disk image containing the EFI System partition."
 DEFINE_boolean verity ${FLAGS_FALSE} \
   "Indicates that boot commands should enable dm-verity."
+DEFINE_string copy_efi_grub "" \
+  "Copy the EFI GRUB image to the specified path."
+DEFINE_string copy_shim "" \
+  "Copy the shim image to the specified path."
 
 # Parse flags
 FLAGS "$@" || exit 1
@@ -208,6 +212,15 @@ case "${FLAGS_target}" in
             sudo cp "/usr/lib/shim/shim.efi" \
                 "${ESP_DIR}/EFI/boot/bootx64.efi"
 	fi
+        # copying from vfat so ignore permissions
+        if [[ -n "${FLAGS_copy_efi_grub}" ]]; then
+            cp --no-preserve=mode "${ESP_DIR}/EFI/boot/grub.efi" \
+                "${FLAGS_copy_efi_grub}"
+        fi
+        if [[ -n "${FLAGS_copy_shim}" ]]; then
+            cp --no-preserve=mode "${ESP_DIR}/EFI/boot/bootx64.efi" \
+                "${FLAGS_copy_shim}"
+        fi
         ;;
     x86_64-xen)
         info "Installing default x86_64 Xen bootloader."
@@ -223,6 +236,11 @@ case "${FLAGS_target}" in
         #FIXME(andrejro): shim not ported to aarch64
         sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
             "${ESP_DIR}/EFI/boot/bootaa64.efi"
+        if [[ -n "${FLAGS_copy_efi_grub}" ]]; then
+            # copying from vfat so ignore permissions
+            cp --no-preserve=mode "${ESP_DIR}/EFI/boot/bootaa64.efi" \
+                "${FLAGS_copy_efi_grub}"
+        fi
         ;;
 esac
 

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -204,6 +204,8 @@ case "${FLAGS_target}" in
                  "/usr/lib/shim/shim.efi"
         else
             sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
+                "${ESP_DIR}/EFI/boot/grub.efi"
+            sudo cp "/usr/lib/shim/shim.efi" \
                 "${ESP_DIR}/EFI/boot/bootx64.efi"
 	fi
         ;;

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -68,6 +68,8 @@ create_prod_image() {
   local image_licenses="${image_name%.bin}_licenses.txt"
   local image_kernel="${image_name%.bin}.vmlinuz"
   local image_pcr_policy="${image_name%.bin}_pcr_policy.zip"
+  local image_grub="${image_name%.bin}.grub"
+  local image_shim="${image_name%.bin}.shim"
 
   start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 
@@ -122,12 +124,22 @@ EOF
       "${root_fs_dir}" \
       "${image_contents}" \
       "${image_kernel}" \
-      "${image_pcr_policy}"
+      "${image_pcr_policy}" \
+      "${image_grub}" \
+      "${image_shim}"
 
-  upload_image -d "${BUILD_DIR}/${image_name}.bz2.DIGESTS" \
-      "${BUILD_DIR}/${image_contents}" \
-      "${BUILD_DIR}/${image_packages}" \
-      "${BUILD_DIR}/${image_name}" \
-      "${BUILD_DIR}/${image_kernel}" \
-      "${BUILD_DIR}/${image_pcr_policy}"
+  # Upload
+  local to_upload=(
+    "${BUILD_DIR}/${image_contents}"
+    "${BUILD_DIR}/${image_packages}"
+    "${BUILD_DIR}/${image_name}"
+    "${BUILD_DIR}/${image_kernel}"
+    "${BUILD_DIR}/${image_pcr_policy}"
+    "${BUILD_DIR}/${image_grub}"
+  )
+  # FIXME(bgilbert): no shim on arm64
+  if [[ -f "${BUILD_DIR}/${image_shim}" ]]; then
+    to_upload+=("${BUILD_DIR}/${image_shim}")
+  fi
+  upload_image -d "${BUILD_DIR}/${image_name}.bz2.DIGESTS" "${to_upload[@]}"
 }


### PR DESCRIPTION
On arm64, extract only GRUB, since there is no shim.  On dev builds, extract neither.

Tested with:
- amd64 dev
- amd64 prod
- arm64 prod
- amd64 prod official