### PR TITLE
build_image: Correctly disable verity on unsupported boards

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -329,7 +329,7 @@ finish_image() {
   case "${FLAGS_board}" in
     amd64-usr) verity_offset=64 ;;
     arm64-usr) verity_offset=512 ;;
-    *) FLAGS_enable_rootfs_verification=${FLAGS_FALSE} ;;
+    *) disable_read_write=${FLAGS_FALSE} ;;
   esac
 
   # Copy kernel to support dm-verity boots


### PR DESCRIPTION
Fixes up missing bit from e630a36e50799ec72305b03a6d6fe354d2b8b059.

cc: @dm0- 