### PR TITLE
Add Secure Boot to the offline signing process

### DIFF
--- a/offline_signing/download.sh
+++ b/offline_signing/download.sh
@@ -3,18 +3,29 @@
 set -ex
 BOARD="$1"
 VERSION="$2"
-GS="gs://builds.release.core-os.net/stable/boards/$BOARD/$VERSION"
+GS="gs://builds.release.core-os.net/unsigned/boards/$BOARD/$VERSION"
 
 cd "${3:-.}"
+
+# The shim only exists for amd64 boards.
+[ "x${BOARD}" = xamd64-usr ] && shim=1 || shim=
 
 gsutil cp \
     "${GS}/coreos_production_image.vmlinuz" \
     "${GS}/coreos_production_image.vmlinuz.sig" \
+    "${GS}/coreos_production_image.grub" \
+    "${GS}/coreos_production_image.grub.sig" \
+    ${shim:+
+    "${GS}/coreos_production_image.shim"
+    "${GS}/coreos_production_image.shim.sig"
+    } \
     "${GS}/coreos_production_update.bin.bz2" \
     "${GS}/coreos_production_update.bin.bz2.sig" \
     "${GS}/coreos_production_update.zip" \
     "${GS}/coreos_production_update.zip.sig" ./
 
 gpg --verify "coreos_production_image.vmlinuz.sig"
+gpg --verify "coreos_production_image.grub.sig"
+[ -z "$shim" ] || gpg --verify "coreos_production_image.shim.sig"
 gpg --verify "coreos_production_update.bin.bz2.sig"
 gpg --verify "coreos_production_update.zip.sig"

--- a/offline_signing/sign.sh
+++ b/offline_signing/sign.sh
@@ -5,14 +5,27 @@ DATA_DIR="$(readlink -f "$1")"
 KEYS_DIR="$(readlink -f "$(dirname "$0")")"
 
 gpg2 --verify "${DATA_DIR}/coreos_production_update.bin.bz2.sig"
-gpg2 --verify "${DATA_DIR}/coreos_production_image.vmlinuz.sig"
 gpg2 --verify "${DATA_DIR}/coreos_production_update.zip.sig"
 bunzip2 --keep "${DATA_DIR}/coreos_production_update.bin.bz2"
 unzip "${DATA_DIR}/coreos_production_update.zip" -d "${DATA_DIR}"
 
 export PATH="${DATA_DIR}:${PATH}"
-
 cd "${DATA_DIR}"
+
+# Sign UEFI binaries for Secure Boot.
+for bin in vmlinuz grub shim
+do
+        [ -e "coreos_production_image.$bin" ] || continue
+        gpg2 --verify "coreos_production_image.$bin.sig"
+        mv "coreos_production_image.$bin" "$bin.unsigned"
+        pesign --in="$bin.unsigned" \
+               --out="coreos_production_image.$bin" \
+               --certdir="${KEYS_DIR}" \
+               --certificate='CoreOS Secure Boot Certificate' \
+               --sign
+done
+
+# Sign the delta, with the Secure Boot signed kernel.
 ./core_sign_update \
     --image "${DATA_DIR}/coreos_production_update.bin" \
     --kernel "${DATA_DIR}/coreos_production_image.vmlinuz" \


### PR DESCRIPTION
I haven't tested the signing part yet.  Consider this a proposal until then.