### PR TITLE
toolchain: always run gcc-config

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -408,7 +408,5 @@ gcc_set_latest_profile() {
         sudo="sudo -E"
     fi
 
-    if [[ "${latest}" != $(gcc-config -c "$1") ]]; then
-        $sudo gcc-config "${latest}"
-    fi
+    $sudo gcc-config "${latest}"
 }


### PR DESCRIPTION
This appears to fix the toolchain bootstrapping failure where `/usr/bin/$CHOST-g++` is not installed when building without a pre-existing catalyst directory.