### PR TITLE
Set coreos.first_boot based on existence of file in ESP

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -355,6 +355,12 @@ finish_image() {
     install_grub=1
     ${BUILD_LIBRARY_DIR}/configure_bootloaders.sh \
       --boot_dir="${root_fs_dir}"/usr/boot
+
+    # Create first-boot flag for grub and Ignition
+    info "Writing first-boot flag"
+    sudo_clobber "${root_fs_dir}/boot/coreos/first_boot" <<EOF
+If this file exists, Ignition will run and then delete the file.
+EOF
   fi
 
   if [[ -n "${FLAGS_developer_data}" ]]; then

--- a/build_library/generate_grub_hashes.py
+++ b/build_library/generate_grub_hashes.py
@@ -47,7 +47,7 @@ commands = [{"value": '\[.*\]', "description": "CoreOS Grub configuration %s" % 
             {"value": 'insmod all_video', "description": "CoreOS Grub configuration %s" % version},
             {"value": 'linux /coreos/vmlinuz-[ab] rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (coreos.autologin=\S+)?', "description": "CoreOS Grub configuration %s" % version},
             {"value": 'menuentry CoreOS \S+ --id=coreos\S* {', "description": "CoreOS Grub configuration %s" % version},
-            {"value": 'search --no-floppy --set first_boot --disk-uuid 00000000-0000-0000-0000-000000000001', "description": "CoreOS Grub configuration %s" % version},
+            {"value": 'search --no-floppy --set randomize_disk_guid --disk-uuid 00000000-0000-0000-0000-000000000001', "description": "CoreOS Grub configuration %s" % version},
             {"value": 'search --no-floppy --set oem --part-label OEM --hint hd0,gpt1', "description": "CoreOS Grub configuration %s" % version},
             {"value": 'set .+', "description": "CoreOS Grub configuration %s" % version},
             {"value": 'setparams CoreOS default', "description": "CoreOS Grub configuration %s" % version},

--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -15,6 +15,7 @@ set timeout=1
 set linux_root="root=LABEL=ROOT"
 set linux_console=""
 set first_boot=""
+set randomize_disk_guid=""
 set oem_id=""
 
 # Anything else the OEM adds should use this variable.
@@ -65,11 +66,15 @@ if [ "$secure_boot" = "0" ]; then
 fi
 
 # Determine if this is a first boot.
-search --no-floppy --set first_boot \
+if [ -f "($root)/coreos/first_boot" ]; then
+    set first_boot="coreos.first_boot=detected"
+fi
+
+# Determine if the disk GUID needs to be randomized.
+search --no-floppy --set randomize_disk_guid \
        --disk-uuid 00000000-0000-0000-0000-000000000001
-if [ -n "$first_boot" ]; then
-    # Note we explicitly request the disk-guid randomization, first_boot only triggers ignition.
-    set first_boot="coreos.first_boot=1 coreos.randomize_disk_guid=00000000-0000-0000-0000-000000000001"
+if [ -n "$randomize_disk_guid" ]; then
+    set randomize_disk_guid="coreos.randomize_disk_guid=00000000-0000-0000-0000-000000000001"
 fi
 
 set oem=""
@@ -111,7 +116,7 @@ if [ "$grub_platform" = efi ]; then
 fi
 
 # Assemble the options applicable to all the kernels below
-set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $extra_options $oem $linux_append"
+set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $randomize_disk_guid $extra_options $oem $linux_append"
 
 # Re-implement grub_abort() since no command exposes it.
 function abort {


### PR DESCRIPTION
Detect first boot based on the existence of a `coreos/first_boot` file in the EFI partition, and set `coreos.first_boot=detected` command line argument when found. We use `detected` rather than `1` so the initramfs knows that it should [mount the ESP and delete the file](https://github.com/coreos/bootengine/pull/107). This lets us defer clearing the first-boot flag until Ignition has run successfully, without having to change the disk GUID after filesystems are mounted.

Continue detecting the first-boot disk GUID and adding the command-line argument to randomize it, since we still want unique disk GUIDs regardless of Ignition.