### PR TITLE
image_to_vm: add initial sakuracloud support

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -42,6 +42,7 @@ VALID_IMG_TYPES=(
     cloudsigma
     packet
     interoute
+    sakuracloud
 )
 
 #list of oem package names, minus the oem- prefix
@@ -63,6 +64,7 @@ VALID_OEM_PACKAGES=(
     cloudsigma
     packet
     interoute
+    sakuracloud
 )
 
 # Set at runtime to one of the above types
@@ -293,6 +295,9 @@ IMG_interoute_DISK_LAYOUT=interoute
 IMG_interoute_CONF_FORMAT=interoute
 IMG_interoute_OEM_PACKAGE=oem-interoute
 IMG_interoute_BUNDLE_FORMAT=ova
+
+## sakuracloud
+IMG_sakuracloud_OEM_PACKAGE=oem-sakuracloud
 
 ###########################################################
 

--- a/contrib/jenkins/jobs/os-board-vm-matrix/config.xml
+++ b/contrib/jenkins/jobs/os-board-vm-matrix/config.xml
@@ -84,6 +84,7 @@
         <string>cloudsigma</string>
         <string>packet</string>
         <string>interoute</string>
+        <string>sakuracloud</string>
       </values>
     </hudson.matrix.TextAxis>
     <hudson.matrix.TextAxis>

--- a/contrib/jenkins/jobs/os-board-vm/config.xml
+++ b/contrib/jenkins/jobs/os-board-vm/config.xml
@@ -69,6 +69,7 @@
               <string>cloudsigma</string>
               <string>packet</string>
               <string>interoute</string>
+              <string>sakuracloud</string>
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>


### PR DESCRIPTION
[SAKURA Cloud](http://cloud.sakura.ad.jp/) is one of the most famous IaaS in Japan. It based on KVM.

I'll make p-r for [coreos/coreos-overlay](https://github.com/coreos/coreos-overlay), [coreos/coreos-metadata](https://github.com/coreos/coreos-metadata) and [coreos/ignition](https://github.com/coreos/ignition) soon.