### PR TITLE
os-release: Add COREOS_BOARD variable

### DIFF
--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -59,6 +59,7 @@ PRETTY_NAME="$OS_PRETTY_NAME"
 ANSI_COLOR="38;5;75"
 HOME_URL="https://coreos.com/"
 BUG_REPORT_URL="https://github.com/coreos/bugs/issues"
+COREOS_BOARD="$FLAGS_board"
 EOF
 sudo ln -sf "../usr/lib/os-release" "${ROOT_FS_DIR}/etc/os-release"
 sudo ln -sf "../../lib/os-release" "${ROOT_FS_DIR}/usr/share/coreos/os-release"


### PR DESCRIPTION
os-release is requested in bug reports, and knowing which board
the problem occurred on is often helpful.
