### PR TITLE
build_library: upload image licenses

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -126,5 +126,6 @@ EOF
   upload_image -d "${BUILD_DIR}/${image_name}.bz2.DIGESTS" \
       "${BUILD_DIR}/${image_contents}" \
       "${BUILD_DIR}/${image_packages}" \
+      "${BUILD_DIR}/${image_licenses}" \
       "${BUILD_DIR}/${image_name}"
 }

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -132,6 +132,7 @@ EOF
   local to_upload=(
     "${BUILD_DIR}/${image_contents}"
     "${BUILD_DIR}/${image_packages}"
+    "${BUILD_DIR}/${image_licenses}"
     "${BUILD_DIR}/${image_name}"
     "${BUILD_DIR}/${image_kernel}"
     "${BUILD_DIR}/${image_pcr_policy}"


### PR DESCRIPTION
We've always generated these license manifests (detailing which ebuilds
are covered by which license), but never published them. This adds these
manifests to the list of published files so that they are publicly
available.