### PR TITLE
Handle Perl downgrades

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -120,7 +120,7 @@ cat <<EOF
 target: stage1
 # stage1 packages aren't published, save in tmp
 pkgcache_path: ${TEMPDIR}/stage1-${ARCH}-packages
-update_seed: yes
+#update_seed: yes
 EOF
 catalyst_stage_default
 }

--- a/update_chroot
+++ b/update_chroot
@@ -176,25 +176,25 @@ done
 
 "${BUILD_LIBRARY_DIR}/set_lsb_release" --root /
 
-EMERGE_FLAGS="-uNv --with-bdeps=y --select"
-REBUILD_FLAGS=""
+EMERGE_FLAGS=( -uNv --with-bdeps=y --select )
+REBUILD_FLAGS=()
 if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
-  EMERGE_FLAGS="${EMERGE_FLAGS} --usepkg"
+  EMERGE_FLAGS+=( --usepkg )
   if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_TRUE}" ]]; then
-    EMERGE_FLAGS+=" --usepkgonly --rebuilt-binaries n"
+    EMERGE_FLAGS+=( --usepkgonly --rebuilt-binaries n )
   fi
   if [ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]; then
-    EMERGE_FLAGS="${EMERGE_FLAGS} --getbinpkg"
+    EMERGE_FLAGS+=( --getbinpkg )
   fi
 
   # Only update toolchain when binpkgs are available.
-  EMERGE_FLAGS+=" $(get_binonly_args $(get_chost_list))"
-  REBUILD_FLAGS+=" $(get_binonly_args $(get_chost_list))"
+  EMERGE_FLAGS+=( $(get_binonly_args $(get_chost_list)) )
+  REBUILD_FLAGS+=( $(get_binonly_args $(get_chost_list)) )
 fi
 
 if [[ "${FLAGS_jobs}" -ne -1 ]]; then
-  EMERGE_FLAGS+=" --jobs=${FLAGS_jobs}"
-  REBUILD_FLAGS+=" --jobs=${FLAGS_jobs}"
+  EMERGE_FLAGS+=( "--jobs=${FLAGS_jobs}" )
+  REBUILD_FLAGS+=( "--jobs=${FLAGS_jobs}" )
 fi
 
 # Perform an update of coreos-devel/sdk-depends and world in the chroot.
@@ -203,7 +203,7 @@ EMERGE_CMD="emerge"
 # In first pass, update portage and toolchains. Lagged updates of both
 # can cause serious issues later.
 info "Updating basic system packages"
-sudo -E ${EMERGE_CMD} --quiet ${EMERGE_FLAGS} \
+sudo -E ${EMERGE_CMD} --quiet "${EMERGE_FLAGS[@]}" \
     dev-util/ccache \
     sys-apps/portage \
     sys-devel/crossdev \
@@ -221,7 +221,7 @@ if [[ "${FLAGS_skip_toolchain_update}" -eq "${FLAGS_FALSE}" && \
 
   for cross_chost in "${CROSS_CHOSTS[@]}"; do
     info "Updating cross ${cross_chost} toolchain"
-    install_cross_toolchain "${cross_chost}" --quiet ${EMERGE_FLAGS}
+    install_cross_toolchain "${cross_chost}" --quiet "${EMERGE_FLAGS[@]}"
   done
 fi
 
@@ -229,14 +229,14 @@ fi
 CHROMITE_BIN="${GCLIENT_ROOT}/chromite/bin"
 if [ "${FLAGS_workon}" -eq "${FLAGS_TRUE}" ]; then
   for pkg in $("${CHROMITE_BIN}/cros_list_modified_packages" --host); do
-    EMERGE_FLAGS+=" --reinstall-atoms=${pkg} --usepkg-exclude=${pkg}"
+    EMERGE_FLAGS+=( "--reinstall-atoms=${pkg}" "--usepkg-exclude=${pkg}" )
   done
 fi
 
 # Second pass, update everything else.
-EMERGE_FLAGS+=" --deep"
+EMERGE_FLAGS+=( --deep )
 info "Updating all SDK packages"
-sudo -E ${EMERGE_CMD} ${EMERGE_FLAGS} \
+sudo -E ${EMERGE_CMD} "${EMERGE_FLAGS[@]}" \
     coreos-devel/sdk-depends world
 
 info "Removing obsolete packages"
@@ -244,7 +244,7 @@ sudo -E ${EMERGE_CMD} --quiet --depclean @unavailable
 
 if portageq list_preserved_libs / >/dev/null; then
   info "Rebuilding packages linked against old libraries"
-  sudo -E ${EMERGE_CMD} ${REBUILD_FLAGS} @preserved-rebuild
+  sudo -E ${EMERGE_CMD} "${REBUILD_FLAGS[@]}" @preserved-rebuild
 fi
 
 # Automatically discard all CONFIG_PROTECT'ed files. Those that are

--- a/update_chroot
+++ b/update_chroot
@@ -197,6 +197,14 @@ if [[ "${FLAGS_jobs}" -ne -1 ]]; then
   REBUILD_FLAGS+=( "--jobs=${FLAGS_jobs}" )
 fi
 
+# Force rebuilding some misbehaving Perl modules during the 5.22 upgrade.
+if : || portageq has_version / '>=dev-lang/perl-5.21'; then
+  EMERGE_FLAGS+=(
+    --reinstall-atoms='dev-perl/File-Slurp dev-perl/Locale-gettext perl-core/File-Temp'
+    --usepkg-exclude='dev-perl/File-Slurp dev-perl/Locale-gettext perl-core/File-Temp'
+  )
+fi
+
 # Perform an update of coreos-devel/sdk-depends and world in the chroot.
 EMERGE_CMD="emerge"
 


### PR DESCRIPTION
This is the reverse of #657 for beta.  If the existing SDK or Jenkins workspace was building alpha/master with the new Perl, ensure the downgrade can succeed (at least with `--nousepkg`).