### PR TITLE
common: Don't export COREOS_BUILD_ID

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -296,6 +296,10 @@ if [[ -f "${REPO_MANIFESTS_DIR}/version.txt" ]]; then
   else
     load_environment_var "${REPO_MANIFESTS_DIR}/version.txt" \
     COREOS_VERSION_ID COREOS_BUILD_ID COREOS_SDK_VERSION
+    # Don't promote COREOS_BUILD_ID into an environment variable when it
+    # didn't start as one, since we don't want it leaking into the SDK
+    # chroot environment via ENVIRONMENT_WHITELIST.
+    declare +x COREOS_BUILD_ID
   fi
   : ${COREOS_BUILD_ID:=$(date +%Y-%m-%d-%H%M)}
 elif [[ -f "${SCRIPT_LOCATION}/version.txt" ]]; then


### PR DESCRIPTION
https://github.com/coreos/scripts/pull/647 started exporting COREOS_BUILD_ID whenever it was found in version.txt, even if its value was blank. Because COREOS_BUILD_ID is in ENVIRONMENT_WHITELIST, this caused generated build IDs to be propagated into the SDK chroot environment and reused for every build in a `cork enter` session. Stop exporting COREOS_BUILD_ID when we set it ourselves.

See also #550.