### PR TITLE
Sign uploaded binary packages

### DIFF
--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -140,7 +140,8 @@ upload_packages() {
 
     local board_packages="${1:-"${BOARD_ROOT}/packages"}"
     local def_upload_path="${UPLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION}"
-    upload_files packages ${def_upload_path} "pkgs/" "${board_packages}"/*
+    sign_and_upload_files packages ${def_upload_path} "pkgs/" \
+        "${board_packages}"/*
 }
 
 # Upload a set of files (usually images) and digest, optionally w/ gpg sig

--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -110,15 +110,17 @@ sign_and_upload_files() {
     local sigs=()
     if [[ -n "${FLAGS_sign}" ]]; then
         local file
+        local sigdir=$(mktemp --directory)
+        trap "rm -rf ${sigdir}" RETURN
         for file in "$@"; do
             if [[ "${file}" =~ \.(asc|gpg|sig)$ ]]; then
                 continue
             fi
 
-            rm -f "${file}.sig"
             gpg --batch --local-user "${FLAGS_sign}" \
+                --output "${sigdir}/${file##*/}.sig" \
                 --detach-sign "${file}" || die "gpg failed"
-            sigs+=( "${file}.sig" )
+            sigs+=( "${sigdir}/${file##*/}.sig" )
         done
     fi
 


### PR DESCRIPTION
This is a work in progress.  There is an issue with `emerge` commands failing unless `PORTAGE_SSH_OPTS=` is set in the environment.  The was this is set up, it only works with the SDK scripts since the `FETCHCOMMAND_GS` and `RESUMECOMMAND_GS` variables are not in the user's login environment.