### PR TITLE
build_library: reformat the license file as json

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -281,6 +281,11 @@ write_licenses() {
 
     local pkg pkg_sep
     for pkg in $(image_packages "$1" | sort); do
+        # Ignore virtual packages since they aren't licensed
+        if [[ "${pkg%%/*}" == "virtual" ]]; then
+            continue
+        fi
+
         local path="$1/var/db/pkg/${pkg%%:*}/LICENSE"
         local lic_str
         if [[ -f "$path" ]]; then

--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -90,7 +90,7 @@ create_dev_image() {
   local root_fs_dir="${BUILD_DIR}/rootfs"
   local image_contents="${image_name%.bin}_contents.txt"
   local image_packages="${image_name%.bin}_packages.txt"
-  local image_licenses="${image_name%.bin}_licenses.txt"
+  local image_licenses="${image_name%.bin}_licenses.json"
 
   start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 

--- a/build_library/ebuild_aci_util.sh
+++ b/build_library/ebuild_aci_util.sh
@@ -15,7 +15,7 @@ create_ebuild_aci_image() {
     local root_fs_dir="${BUILD_DIR}/rootfs"
     local image_contents="${image_name%.bin}_contents.txt"
     local image_packages="${image_name%.bin}_packages.txt"
-    local image_licenses="${image_name%.bin}_licenses.txt"
+    local image_licenses="${image_name%.bin}_licenses.json"
 
     start_image \
         "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"

--- a/build_library/oem_aci_util.sh
+++ b/build_library/oem_aci_util.sh
@@ -22,7 +22,7 @@ create_oem_aci_image() {
     local root_fs_dir="${BUILD_DIR}/rootfs"
     local image_contents="${image_name%.bin}_contents.txt"
     local image_packages="${image_name%.bin}_packages.txt"
-    local image_licenses="${image_name%.bin}_licenses.txt"
+    local image_licenses="${image_name%.bin}_licenses.json"
 
     start_image \
         "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -65,7 +65,7 @@ create_prod_image() {
   local root_fs_dir="${BUILD_DIR}/rootfs"
   local image_contents="${image_name%.bin}_contents.txt"
   local image_packages="${image_name%.bin}_packages.txt"
-  local image_licenses="${image_name%.bin}_licenses.txt"
+  local image_licenses="${image_name%.bin}_licenses.json"
   local image_kernel="${image_name%.bin}.vmlinuz"
   local image_pcr_policy="${image_name%.bin}_pcr_policy.zip"
   local image_grub="${image_name%.bin}.grub"


### PR DESCRIPTION
This changes the format from:

    sys-apps/systemd-212-r8::coreos GPL-2 LGPL-2.1 MIT public-domain

to a JSON structure:

```json
[
  {
    "project": "sys-apps/systemd-212-r8::coreos",
    "license": ["GPL-2", "LGPL-2.1", "MIT", "public-domain"]
  }
]
```

We don't have to worry about the changing format because the previous
format was never published. This is designed to match the
bill-of-materials [1] format so that it can be consumed by the site.

[1]: https://github.com/coreos/license-bill-of-materials