### PR TITLE
lsb_release: update BUG_REPORT_URL

### DIFF
--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -58,7 +58,7 @@ BUILD_ID=$COREOS_BUILD_ID
 PRETTY_NAME="$OS_PRETTY_NAME"
 ANSI_COLOR="38;5;75"
 HOME_URL="https://coreos.com/"
-BUG_REPORT_URL="https://github.com/coreos/bugs/issues"
+BUG_REPORT_URL="https://issues.coreos.com"
 COREOS_BOARD="$FLAGS_board"
 EOF
 sudo ln -sf "../usr/lib/os-release" "${ROOT_FS_DIR}/etc/os-release"


### PR DESCRIPTION
See https://github.com/coreos/coreos-overlay/pull/2463 for the
reasoning.

This was missed in that sweep of changes.

cc @crawford 