### PR TITLE
build_image: do not use gs:// URLs in dev images

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -26,7 +26,7 @@ PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
 PORTDIR="/var/lib/portage/portage-stable"
 PORTDIR_OVERLAY="/var/lib/portage/coreos-overlay"
-PORTAGE_BINHOST="$(get_board_binhost $BOARD $COREOS_VERSION_ID)"
+PORTAGE_BINHOST="$(get_board_binhost $BOARD $COREOS_VERSION_ID | sed 's/^gs:/http:/')"
 EOF
 
 sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF


### PR DESCRIPTION
When building dev images, the `PORTAGE_BINHOST` value during build time is written to the image's `make.conf`.  This breaks the default binary package setup, since Jenkins is using `gs://` URLs for signed package verification and authenticated downloads, and the `make.conf` doesn't inherit the `GS_*` variables to handle those schemes.

This should be reverted when signed packages are properly supported by default in the dev images.