### PR TITLE
build_image: do not use gs:// URLs in dev images

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -26,7 +26,7 @@ PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
 PORTDIR="/var/lib/portage/portage-stable"
 PORTDIR_OVERLAY="/var/lib/portage/coreos-overlay"
-PORTAGE_BINHOST="$(get_board_binhost $BOARD $COREOS_VERSION_ID)"
+PORTAGE_BINHOST="$(get_board_binhost $BOARD $COREOS_VERSION_ID | sed 's/^gs:/http:/')"
 EOF
 
 sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF


### PR DESCRIPTION
I want to prevent passing `gs://` URLs in stable so we don't have to worry about disabling signed package verifications for future release builds.

Backports #675.