### PR TITLE
Change default value of dhcp for vmware template to no

### DIFF
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -49,7 +49,7 @@
         <Description>MAC for network interface 0</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.dhcp" ovf:value="yes">
+                ovf:key="guestinfo.interface.0.dhcp" ovf:value="no">
         <Label>DHCP support for network interface 0</Label>
         <Description>DHCP support for network interface 0</Description>
       </Property>
@@ -210,4 +210,4 @@
       <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
     </VirtualHardwareSection>
   </VirtualSystem>
-</Envelope>                                 
+</Envelope>


### PR DESCRIPTION
When OVA template is not being used, the default dhcp value yes will
trigger cloud-init to generate a 00-.network file, which will break
network connectivity Intermittently. Please see the details here:
https://github.com/coreos/bugs/issues/1802#issuecomment-297847614