### PR TITLE
enter_chroot: Fix ownership of /run/user/UID

### DIFF
--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -232,8 +232,8 @@ setup_env() {
     if [[ -d /run/shm && ! -L /run/shm ]]; then
       setup_mount /run/shm "--bind" /run/shm
     fi
-    mkdir -p /run/user/${SUDO_UID}
-    chown ${SUDO_UID}:${SUDO_GID} /run/user/${SUDO_UID}
+    mkdir -p "${MOUNTED_PATH}/run/user/${SUDO_UID}"
+    chown ${SUDO_UID}:${SUDO_GID} "${MOUNTED_PATH}/run/user/${SUDO_UID}"
 
     # Do this early as it's slow and only needs basic mounts (above).
     generate_locales &


### PR DESCRIPTION
We were chowning the host directory, not the one in the chroot.

Host gpg &ge; 2.1.13 puts the gpg-agent socket in `/run/user/UID/gnupg`, which is bind-mounted into the chroot, but the SDK gpg was ignoring it because `/run/user/UID` was not owned by `UID`. This broke tag signing with YubiKeys.