### PR TITLE
Revert Perl workarounds

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -120,7 +120,7 @@ cat <<EOF
 target: stage1
 # stage1 packages aren't published, save in tmp
 pkgcache_path: ${TEMPDIR}/stage1-${ARCH}-packages
-#update_seed: yes
+update_seed: yes
 EOF
 catalyst_stage_default
 }

--- a/update_chroot
+++ b/update_chroot
@@ -197,14 +197,6 @@ if [[ "${FLAGS_jobs}" -ne -1 ]]; then
   REBUILD_FLAGS+=( "--jobs=${FLAGS_jobs}" )
 fi
 
-# Force rebuilding some misbehaving Perl modules for the 5.22 upgrade.
-if : || portageq has_version / '<dev-lang/perl-5.22'; then
-  EMERGE_FLAGS+=(
-    --reinstall-atoms='dev-perl/File-Slurp dev-perl/Locale-gettext perl-core/File-Temp'
-    --usepkg-exclude='dev-perl/File-Slurp dev-perl/Locale-gettext perl-core/File-Temp'
-  )
-fi
-
 # Perform an update of coreos-devel/sdk-depends and world in the chroot.
 EMERGE_CMD="emerge"
 


### PR DESCRIPTION
Since 1353 (with the last old Perl SDK) rotates out of stable next week, drop the Perl SDK workarounds.

I am going to throw this at Jenkins first, but there should be no problem with merging it before 1353 is retired.  The workarounds would only matter if we needed to build a new 1353 release before Monday, but even then, an alternate workaround is to just delete all Jenkins workspaces after a 1353 build.