### PR TITLE
Transition beta to handle Perl 5.24

### DIFF
--- a/update_chroot
+++ b/update_chroot
@@ -197,13 +197,11 @@ if [[ "${FLAGS_jobs}" -ne -1 ]]; then
   REBUILD_FLAGS+=( "--jobs=${FLAGS_jobs}" )
 fi
 
-# Force rebuilding some misbehaving Perl modules for the 5.22 upgrade.
-if : || portageq has_version / '<dev-lang/perl-5.22'; then
-  EMERGE_FLAGS+=(
-    --reinstall-atoms='dev-perl/File-Slurp dev-perl/Locale-gettext perl-core/File-Temp'
-    --usepkg-exclude='dev-perl/File-Slurp dev-perl/Locale-gettext perl-core/File-Temp'
-  )
-fi
+# Force rebuilding some misbehaving Perl modules to downgrade from 5.24.
+EMERGE_FLAGS+=(
+  --reinstall-atoms='dev-perl/File-Slurp dev-perl/Locale-gettext dev-perl/XML-Parser perl-core/File-Temp virtual/perl-File-Temp'
+  --usepkg-exclude='dev-perl/File-Slurp dev-perl/Locale-gettext dev-perl/XML-Parser perl-core/File-Temp virtual/perl-File-Temp'
+)
 
 # Perform an update of coreos-devel/sdk-depends and world in the chroot.
 EMERGE_CMD="emerge"


### PR DESCRIPTION
This changes the workaround from supporting upgrading Perl 5.20 to 5.22, to supporting downgrading from 5.24 to 5.22.

Part of coreos/portage-stable#556.