### PR TITLE
Add workarounds for upgrading to Perl 5.24

### DIFF
--- a/build_library/check_root
+++ b/build_library/check_root
@@ -28,10 +28,9 @@ IGNORE_MISSING = {
     "dev-lang/go-bootstrap":    [SonameAtom("x86_32", "libc.so.6"),
                                  SonameAtom("x86_64", "libc.so.6")],
 
-    # RPATHs and symlinks apparently confuse the perl-5.22 package
-    "dev-lang/perl":            [SonameAtom("arm_64", "libperl.so.5.22.3"),
-                                 SonameAtom("x86_32", "libperl.so.5.22.3"),
-                                 SonameAtom("x86_64", "libperl.so.5.22.3")],
+    # RPATHs and symlinks apparently confuse the perl-5.24 package
+    "dev-lang/perl":            [SonameAtom("arm_64", "libperl.so.5.24.1"),
+                                 SonameAtom("x86_64", "libperl.so.5.24.1")],
 
     # https://bugs.gentoo.org/show_bug.cgi?id=554582
     "net-firewall/ebtables":    [SonameAtom("arm_64", "libebt_802_3.so"),

--- a/update_chroot
+++ b/update_chroot
@@ -197,6 +197,12 @@ if [[ "${FLAGS_jobs}" -ne -1 ]]; then
   REBUILD_FLAGS+=( "--jobs=${FLAGS_jobs}" )
 fi
 
+# Force rebuilding some misbehaving Perl modules for the 5.24 upgrade.
+EMERGE_FLAGS+=(
+  --reinstall-atoms='dev-perl/File-Slurp dev-perl/Locale-gettext dev-perl/XML-Parser perl-core/File-Temp virtual/perl-File-Temp'
+  --usepkg-exclude='dev-perl/File-Slurp dev-perl/Locale-gettext dev-perl/XML-Parser perl-core/File-Temp virtual/perl-File-Temp'
+)
+
 # Perform an update of coreos-devel/sdk-depends and world in the chroot.
 EMERGE_CMD="emerge"
 


### PR DESCRIPTION
This is #657 again for upgrading 5.22 to 5.24.

Part of coreos/portage-stable#556.