### PR TITLE
offline_signing: take download channel as an arg

### DIFF
--- a/offline_signing/download.sh
+++ b/offline_signing/download.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 
-set -ex
-BOARD="$1"
-VERSION="$2"
-GS="gs://builds.release.core-os.net/stable/boards/$BOARD/$VERSION"
+set -eux
 
-cd "${3:-.}"
+BOARD="${1?Must provide a board (e.g. amd64-usr)}"
+VERSION="${2?Must provide a version (e.g. 1234.0.0)}"
+CHANNEL="${3?Must provide a channel (e.g. alpha)}"
+
+if ! [[ "${CHANNEL}" =~ alpha|beta|stable ]]; then
+    echo "Invalid channel ${CHANNEL}"
+    echo "Usage: $0 <BOARD> <VERSION> <CHANNEL> [OUTPUT DIR]"
+    exit 1
+fi
+
+GS="gs://builds.release.core-os.net/${CHANNEL}/boards/$BOARD/$VERSION"
+
+cd "${4:-.}"
 
 gsutil cp \
     "${GS}/coreos_production_image.vmlinuz" \


### PR DESCRIPTION
A validation for the channel variable was also added so old users of the
3-argument form would get a sensical error if they used a invocation
from their history.

Just a small quality-of-life thing.