### PR TITLE
Drop ISO/PXE support for amd64-generic, and an unused variable

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -18,7 +18,6 @@ configure_dev_portage() {
 # make.conf for CoreOS dev images
 ARCH=$(get_board_arch $BOARD)
 CHOST=$(get_board_chost $BOARD)
-BOARD_USE="$BOARD"
 
 # Use /var/lib/portage instead of /usr/portage
 DISTDIR="/var/lib/portage/distfiles"

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -574,25 +574,11 @@ _write_cpio_common() {
     local dst_dir=$(_dst_dir)
     local vmlinuz_name="$(_dst_name ".vmlinuz")"
     local base_dir="${VM_TMP_ROOT}/usr"
-    local squashfs="usr.squashfs"
 
     sudo mkdir -p "${cpio_target}/etc"
 
-    # If not a /usr image pack up root instead
-    if ! mountpoint -q "${base_dir}"; then
-        base_dir="${VM_TMP_ROOT}"
-        squashfs="newroot.squashfs"
-
-        # The STATE partition and all of its bind mounts shouldn't be
-        # packed into the squashfs image. Just ROOT.
-        sudo umount --all-targets "${VM_TMP_ROOT}/media/state"
-
-        # Inject /usr/.noupdate into squashfs to disable update_engine
-        echo "/usr/.noupdate f 444 root root echo -n" >"${VM_TMP_DIR}/extra"
-    else
-        # Inject /usr/.noupdate into squashfs to disable update_engine
-        echo "/.noupdate f 444 root root echo -n" >"${VM_TMP_DIR}/extra"
-    fi
+    # Inject /usr/.noupdate into squashfs to disable update_engine
+    echo "/.noupdate f 444 root root echo -n" >"${VM_TMP_DIR}/extra"
 
     # Set correct group for PXE/ISO, which has no writeable /etc
     echo /usr/share/coreos/update.conf f 644 root root \
@@ -601,7 +587,7 @@ _write_cpio_common() {
 
     # Build the squashfs, embed squashfs into a gzipped cpio
     pushd "${cpio_target}" >/dev/null
-    sudo mksquashfs "${base_dir}" "./${squashfs}" -pf "${VM_TMP_DIR}/extra"
+    sudo mksquashfs "${base_dir}" "./usr.squashfs" -pf "${VM_TMP_DIR}/extra"
     find . | cpio -o -H newc | gzip > "$2"
     popd >/dev/null
 

--- a/setup_board
+++ b/setup_board
@@ -256,7 +256,6 @@ PORTAGE_USERNAME="$(portageq envvar PORTAGE_USERNAME)"
 # Board specific settings
 CHOST="${BOARD_CHOST}"
 ROOT="${BOARD_ROOT}/"
-BOARD_USE="${BOARD_VARIANT}"
 PKGDIR="${BOARD_ROOT}/var/lib/portage/pkgs"
 PORT_LOGDIR="${BOARD_ROOT}/var/log/portage"
 PORTAGE_TMPDIR="${BOARD_ROOT}/var/tmp"


### PR DESCRIPTION
See https://github.com/coreos/coreos-overlay/pull/2610 for `BOARD_USE`.