### PR TITLE
core_sign_update: fix flag parsing for keys_separator

### DIFF
--- a/core_sign_update
+++ b/core_sign_update
@@ -20,7 +20,7 @@ DEFINE_string kernel "" "The kernel image"
 DEFINE_string output "" "Output file"
 DEFINE_string private_keys "" "Path or pkcs11 URI to private keys."
 DEFINE_string public_keys "" "Path to public keys in .pem format."
-DEFINE string keys_separator ":" "Separator for the above keys"
+DEFINE_string keys_separator ":" "Separator for the above keys"
 
 # Parse command line
 FLAGS "$@" || exit 1
@@ -47,8 +47,8 @@ delta_generator \
     -out_file update
 
 # The separator is configurable for backwards compatibility with old `sign.sh` scripts.
-IFS="${keys_separator}" read -a private_keys <<< "$FLAGS_private_keys"
-IFS="${keys_separator}" read -a public_keys <<< "$FLAGS_public_keys"
+IFS="${FLAGS_keys_separator}" read -a private_keys <<< "$FLAGS_private_keys"
+IFS="${FLAGS_keys_separator}" read -a public_keys <<< "$FLAGS_public_keys"
 
 if [ ${#private_keys[@]} -ne ${#public_keys[@]} ]; then
 	echo "mismatch in count of private keys and public keys"


### PR DESCRIPTION
Introduced in #710, whoops.