### PR TITLE
Support dropping Python 3 in alpha

### DIFF
--- a/update_chroot
+++ b/update_chroot
@@ -210,6 +210,7 @@ EMERGE_CMD="emerge"
 # can cause serious issues later.
 info "Updating basic system packages"
 sudo -E ${EMERGE_CMD} --quiet "${EMERGE_FLAGS[@]}" \
+    app-portage/gentoolkit \
     dev-util/ccache \
     sys-apps/portage \
     sys-devel/crossdev \


### PR DESCRIPTION
This is to run test builds for Jenkins SDKs downgrading to releases without Python 3.