### PR TITLE
vm_image_util: Update to use edk2 package

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -713,16 +713,17 @@ _write_qemu_uefi_conf() {
 
     case $BOARD in
         amd64-usr)
-            cp "/usr/share/edk2-ovmf/OVMF_CODE.fd" "$(_dst_dir)/${flash_ro}"
-            cp "/usr/share/edk2-ovmf/OVMF_VARS.fd" "$(_dst_dir)/${flash_rw}"
+            cp "/usr/share/edk2/OVMF_CODE.fd" "$(_dst_dir)/${flash_ro}"
+            cp "/usr/share/edk2/OVMF_VARS.fd" "$(_dst_dir)/${flash_rw}"
             ;;
         arm64-usr)
-            info "Updating edk2-armvirt in /build/${BOARD}"
-            emerge-${BOARD} --nodeps --select -qugKN sys-firmware/edk2-armvirt
-            # this bit of magic comes from http://tech.donghao.org/2014/12/18/running-fedora-21-on-qemu-system-aarch64/
-            cat "/build/${BOARD}/usr/share/edk2-armvirt/QEMU_EFI.fd" /dev/zero | \
+            # Get edk2 files into local build workspace.
+            info "Updating edk2 in /build/${BOARD}"
+            emerge-${BOARD} --nodeps --select -qugKN sys-firmware/edk2
+            # Create 64MiB flash device image files.
+            cat "/build/${BOARD}/usr/share/edk2/QEMU_EFI.fd" /dev/zero | \
                 dd iflag=fullblock bs=1M count=64 of="$(_dst_dir)/${flash_ro}" \
-                status=none
+                    status=none
             dd if=/dev/zero bs=1M count=64 of="$(_dst_dir)/${flash_rw}" \
                 status=none
             ;;

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -721,11 +721,13 @@ _write_qemu_uefi_conf() {
             info "Updating edk2 in /build/${BOARD}"
             emerge-${BOARD} --nodeps --select -qugKN sys-firmware/edk2
             # Create 64MiB flash device image files.
-            cat "/build/${BOARD}/usr/share/edk2/QEMU_EFI.fd" /dev/zero | \
-                dd iflag=fullblock bs=1M count=64 of="$(_dst_dir)/${flash_ro}" \
-                    status=none
             dd if=/dev/zero bs=1M count=64 of="$(_dst_dir)/${flash_rw}" \
                 status=none
+            cp "/build/${BOARD}/usr/share/edk2/QEMU_EFI.fd" \
+                "$(_dst_dir)/${flash_ro}.work"
+            truncate --reference="$(_dst_dir)/${flash_rw}" \
+                "$(_dst_dir)/${flash_ro}.work"
+            mv "$(_dst_dir)/${flash_ro}.work" "$(_dst_dir)/${flash_ro}"
             ;;
     esac
 


### PR DESCRIPTION
Depends on: 
 https://github.com/coreos/portage-stable/pull/566 (bump(dev-lang/nasm): sync with upstream)
 https://github.com/coreos/coreos-overlay/pull/2665 (sys-firmware/edk2: New package)