### PR TITLE
Revert "update_chroot: fix SDK updates during the Perl 5.24 upgrade" in beta

### DIFF
--- a/update_chroot
+++ b/update_chroot
@@ -197,12 +197,6 @@ if [[ "${FLAGS_jobs}" -ne -1 ]]; then
   REBUILD_FLAGS+=( "--jobs=${FLAGS_jobs}" )
 fi
 
-# Force rebuilding some misbehaving Perl modules for the 5.24 upgrade.
-EMERGE_FLAGS+=(
-  --reinstall-atoms='dev-perl/File-Slurp dev-perl/Locale-gettext dev-perl/XML-Parser perl-core/File-Temp virtual/perl-File-Temp'
-  --usepkg-exclude='dev-perl/File-Slurp dev-perl/Locale-gettext dev-perl/XML-Parser perl-core/File-Temp virtual/perl-File-Temp'
-)
-
 # Perform an update of coreos-devel/sdk-depends and world in the chroot.
 EMERGE_CMD="emerge"
 


### PR DESCRIPTION
This reverts commit 6508cf3faaef0643e6ece9124048591c7435de4f.

All update channels are now using Perl 5.24, so workarounds are no longer required.