### PR TITLE
build_torcx_store: hold back Docker to 1.12 for 1492

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -162,7 +162,7 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-17.05
+        =app-torcx/docker-1.12
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
For https://github.com/coreos/bugs/issues/1930.