### PR TITLE
build_library: Add Vagrant box files

### DIFF
--- a/build_library/vagrant/Vagrantfile
+++ b/build_library/vagrant/Vagrantfile
@@ -1,0 +1,31 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+if Vagrant::VERSION < "1.6.0"
+  raise "Need at least vagrant version 1.6.0, please update"
+end
+
+require_relative 'change_host_name.rb'
+require_relative 'configure_networks.rb'
+require_relative 'base_mac.rb'
+
+Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+
+  # SSH in as the default 'core' user, it has the vagrant ssh key.
+  config.ssh.username = "core"
+
+  # Disable the base shared folder, guest additions are unavailable.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :virtualbox do |vb|
+    # Guest Additions are unavailable.
+    vb.check_guest_additions = false
+    vb.functional_vboxsf = false
+
+    # Fix docker not being able to resolve private registry in VirtualBox
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+  end
+end

--- a/build_library/vagrant/base_mac.rb
+++ b/build_library/vagrant/base_mac.rb
@@ -1,0 +1,4 @@
+# This file must be rewritten with a real value for VirtualBox
+Vagrant.configure("2") do |config|
+  config.vm.base_mac = "080027000000"
+end

--- a/build_library/vagrant/change_host_name.rb
+++ b/build_library/vagrant/change_host_name.rb
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+# NOTE: This monkey-patching is done to disable to old cloud config based
+# change_host_name built into the upstream vagrant project
+
+require Vagrant.source_root.join("plugins/guests/coreos/cap/change_host_name.rb")
+
+module VagrantPlugins
+  module GuestCoreOS
+    module Cap
+      class ChangeHostName
+        def self.change_host_name(machine, name)
+        end
+      end
+    end
+  end
+end

--- a/build_library/vagrant/configure_networks.rb
+++ b/build_library/vagrant/configure_networks.rb
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+# NOTE: This monkey-patching is done to disable to old cloud config based
+# configure_networks built into the upstream vagrant project
+
+require Vagrant.source_root.join("plugins/guests/coreos/cap/configure_networks.rb")
+
+module VagrantPlugins
+  module GuestCoreOS
+    module Cap
+      class ConfigureNetworks
+        def self.configure_networks(machine, networks)
+        end
+      end
+    end
+  end
+end

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -150,11 +150,10 @@ IMG_vagrant_CONF_FORMAT=vagrant
 IMG_vagrant_OEM_PACKAGE=oem-vagrant
 
 ## vagrant_virtualbox
-IMG_vagrant_virtualbox_FS_HOOK=box
 IMG_vagrant_virtualbox_BUNDLE_FORMAT=box
 IMG_vagrant_virtualbox_DISK_FORMAT=vmdk_ide
 IMG_vagrant_virtualbox_DISK_LAYOUT=vagrant
-IMG_vagrant_virtualbox_CONF_FORMAT=vagrant
+IMG_vagrant_virtualbox_CONF_FORMAT=vagrant_virtualbox
 IMG_vagrant_virtualbox_OEM_PACKAGE=oem-vagrant-virtualbox
 
 ## vagrant_vmware
@@ -516,6 +515,7 @@ run_fs_hook() {
     fi
 }
 
+# FIXME(bgilbert): drop FS hooks once this is unused
 _run_box_fs_hook() {
     # Copy basic Vagrant configs from OEM
     mkdir -p "${VM_TMP_DIR}/box"
@@ -955,10 +955,30 @@ EOF
     VM_GENERATED_FILES+=( "$ovf" "${VM_README}" )
 }
 
+_setup_box_files() {
+    mkdir -p "${VM_TMP_DIR}/box"
+    cp -r "${BUILD_LIBRARY_DIR}/vagrant/." "${VM_TMP_DIR}/box"
+}
+
 _write_vagrant_conf() {
     local vm_mem="${1:-$(_get_vm_opt MEM)}"
     local ovf="${VM_TMP_DIR}/box/box.ovf"
     local mac="${VM_TMP_DIR}/box/base_mac.rb"
+
+    "${BUILD_LIBRARY_DIR}/virtualbox_ovf.sh" \
+            --vm_name "$VM_NAME" \
+            --disk_vmdk "${VM_DST_IMG}" \
+            --memory_size "$vm_mem" \
+            --output_ovf "$ovf" \
+            --output_vagrant "$mac"
+}
+
+_write_vagrant_virtualbox_conf() {
+    local vm_mem="${1:-$(_get_vm_opt MEM)}"
+    local ovf="${VM_TMP_DIR}/box/box.ovf"
+    local mac="${VM_TMP_DIR}/box/base_mac.rb"
+
+    _setup_box_files
 
     "${BUILD_LIBRARY_DIR}/virtualbox_ovf.sh" \
             --vm_name "$VM_NAME" \


### PR DESCRIPTION
No longer have the OEM install them in the OEM partition only for `vm_image_util.sh` to move them back out. For now this only applies to the `vagrant_virtualbox` image, but the goal is to migrate all the Vagrant
images and drop the FS hook.

Box files copied from coreos/coreos-overlay@bd0cd7685ebf71a133c1b70f5ebd5a0b3393ac70 `coreos-base/oem-vagrant-virtualbox/files/box`.

cc @AlexNPavel 