### PR TITLE
build_torcx_store: emerge quietly

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -81,6 +81,7 @@ function torcx_build() (
             --oneshot \
             --root="${tmproot}" \
             --root-deps=rdeps \
+            --quiet \
             "${pkg}"
 )
 


### PR DESCRIPTION
Add `--quiet` so build_torcx_store doesn't flood the terminal.