### PR TITLE
build_torcx_store: Bump the Docker image to 17.06

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -163,7 +163,7 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-17.05
+        =app-torcx/docker-17.06
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
Part of coreos/coreos-overlay#2718.