### PR TITLE
scripts: add more options in qemu script

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -53,6 +53,15 @@ check_conflict() {
 
 while [ $# -ge 1 ]; do
     case "$1" in
+        -vm-name)
+            VM_NAME="$2"
+            shift 2 ;; 
+        -ncpus)
+            VM_NCPUS="$2"
+            shift 2 ;; 
+        -memory)
+            VM_MEMORY="$2"
+            shift 2 ;;
         -i|-ignition-config)
             IGNITION_CONFIG_FILE="$2"
             shift 2 ;;


### PR DESCRIPTION
scripts: add more options in qemu script

I frequently need to change the number of processors, memory and VM name. This change allows the user to specify these options when booting CoreOS from the qemu script.