### PR TITLE
[WIP] rework torcx uploading to include a manifest

### DIFF
--- a/build_image
+++ b/build_image
@@ -33,7 +33,7 @@ DEFINE_string base_pkg "coreos-base/coreos" \
 DEFINE_string base_dev_pkg "coreos-base/coreos-dev" \
   "The base portage package to base the build off of (only applies to dev images)"
 DEFINE_string torcx_store "${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest" \
-  "Directory of torcx images to copy into the vendor store (or blank for none)"
+  "Directory containing a torcx manifest describing torcx packages for this image (or blank for none)"
 DEFINE_string output_root "${DEFAULT_BUILD_ROOT}/images" \
   "Directory in which to place image result directories (named by version)"
 DEFINE_string disk_layout "" \
@@ -107,6 +107,7 @@ fi
 . "${BUILD_LIBRARY_DIR}/prod_image_util.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/dev_image_util.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/test_image_content.sh" || exit 1
+. "${BUILD_LIBRARY_DIR}/torcx_manifest.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/vm_image_util.sh" || exit 1
 
 PROD_IMAGE=0

--- a/build_image
+++ b/build_image
@@ -32,8 +32,8 @@ DEFINE_string base_pkg "coreos-base/coreos" \
   "The base portage package to base the build off of (only applies to prod images)"
 DEFINE_string base_dev_pkg "coreos-base/coreos-dev" \
   "The base portage package to base the build off of (only applies to dev images)"
-DEFINE_string torcx_store "${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest" \
-  "Directory containing a torcx manifest describing torcx packages for this image (or blank for none)"
+DEFINE_string torcx_manifest "${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest/torcx_manifest.json" \
+  "The torcx manifest describing torcx packages for this image (or blank for none)"
 DEFINE_string output_root "${DEFAULT_BUILD_ROOT}/images" \
   "Directory in which to place image result directories (named by version)"
 DEFINE_string disk_layout "" \
@@ -89,8 +89,8 @@ switch_to_strict_mode
 check_gsutil_opts
 
 # Patch around default values not being able to depend on other flags.
-if [ "x${FLAGS_torcx_store}" = "x${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest" ]; then
-  FLAGS_torcx_store="${DEFAULT_BUILD_ROOT}/torcx/${FLAGS_board}/latest"
+if [ "x${FLAGS_torcx_manifest}" = "x${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest/torcx_manifest.json" ]; then
+  FLAGS_torcx_manifest="${DEFAULT_BUILD_ROOT}/torcx/${FLAGS_board}/latest/torcx_manifest.json"
 fi
 
 # If downloading packages is enabled ensure the board is configured properly.

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -425,9 +425,9 @@ finish_image() {
   local disk_img="${BUILD_DIR}/${image_name}"
 
   # Copy in packages from the torcx store that are marked as being on disk
-  if [ -n "${FLAGS_torcx_store}" ]; then
+  if [ -n "${FLAGS_torcx_manifest}" ]; then
     sudo cp -dt "${root_fs_dir}"/usr/share/torcx/store \
-        "${FLAGS_torcx_store}"/*.torcx.tgz
+        "${FLAGS_torcx_manifest}"/*.torcx.tgz
   fi
 
   # Only enable rootfs verification on prod builds.

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -424,7 +424,7 @@ finish_image() {
   local install_grub=0
   local disk_img="${BUILD_DIR}/${image_name}"
 
-  # Copy in a vendor torcx store if requested.
+  # Copy in packages from the torcx store that are marked as being on disk
   if [ -n "${FLAGS_torcx_store}" ]; then
     sudo cp -dt "${root_fs_dir}"/usr/share/torcx/store \
         "${FLAGS_torcx_store}"/*.torcx.tgz

--- a/build_library/torcx_manifest.sh
+++ b/build_library/torcx_manifest.sh
@@ -1,0 +1,97 @@
+# Copyright (c) 2017 The Container Linux by CoreOS Authors. All rights
+# reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# torcx_manifest.sh contains helper functions for creating, editing, and
+# reading torcx manifest files.
+
+# create_empty creates an empty torcx manfiest at the given path.
+function torcx_manifest::create_empty() {
+  local path="${1}"
+  jq '.' > "${path}" <<EOF
+{
+  "kind": "torcx-package-list-v0",
+  "value": {
+    "packages": []
+  }
+}
+EOF
+}
+
+# add_pkg adds a new version of a package to the torcx manifest specified by
+# path.
+# That manifest will be edited to include this version, with the associated
+# package of the given name being created as well if necessary.
+function torcx_manifest::add_pkg() {
+  path="${1}"; shift
+  name="${1}"; shift
+  version="${1}"; shift
+  pkg_hash="${1}"; shift
+  cas_digest="${1}"; shift
+  source_package="${1}"; shift
+  update_default="${1}"; shift
+
+  local manifest=$(cat "${path}")
+  local pkg_version_obj=$(jq '.' <<EOF
+{
+  "version": "${version}",
+  "hash": "${pkg_hash}",
+  "casDigest": "${cas_digest}",
+  "sourcePackage": "${source_package}",
+  "locations": []
+}
+EOF
+)
+
+  for location in "${@}"; do
+    if [[ "${location}" == /* ]]; then
+      # filepath
+      pkg_version_obj=$(jq ".locations |= . + [{\"path\": \"${location}\"}]" <(echo "${pkg_version_obj}"))
+    else
+      # url
+      pkg_version_obj=$(jq ".locations |= . + [{\"url\": \"${location}\"}]" <(echo "${pkg_version_obj}"))
+    fi
+  done
+
+
+  local existing_pkg="$(echo "${manifest}" | jq ".value.packages[] | select(.name == \"${name}\")")"
+
+  # If there isn't yet a package in the manifest for $name, initialize it to an empty one.
+  if [[ "${existing_pkg}" == "" ]]; then
+    pkg_json=$(cat <<EOF
+    {
+      "name": "${name}",
+      "versions": []
+    }
+EOF
+)
+    manifest="$(echo "${manifest}" | jq ".value.packages |= . + [${pkg_json}]")"
+  fi
+
+  if [[ "${update_default}" == "true" ]]; then
+    manifest="$(echo "${manifest}" | jq "(.value.packages[] | select(.name = \"${name}\") | .defaultVersion) |= \"${version}\"")"
+  fi
+
+  # append this specific package version to the manifest
+  manifest="$(echo "${manifest}" | jq "(.value.packages[] | select(.name = \"${name}\") | .versions) |= . + [${pkg_version_obj}]")"
+
+  echo "${manifest}" | jq '.' > "${path}"
+}
+
+# get_pkg_names returns the list of packages in a given manifest. Each package
+# may have one or more versions associated with it.
+#
+# Example:
+#     pkg_name_arr=($(torcx_manifest::get_pkg_names "torcx_manifest.json"))
+function torcx_manifest::get_pkg_names() {
+  local file="${1}"
+  jq -r '.value.packages[].name' < "${file}"
+}
+
+# get_digests returns the list of digests for a given package. 
+function torcx_manifest::get_digests() {
+  local file="${1}"
+  local name="${2}"
+  jq -r ".value.packages[] | select(.name == \"${name}\").versions[].casDigest" < "${file}"
+}

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -95,7 +95,7 @@ function torcx_package() {
         local version=${pkg:${#name}+1}
         local manifest_path="${2}"
         local type="${3}"
-        local deppkg digest file rpath sha512sum source_pkg tmproot tmppkgroot update_default
+        local deppkg digest file rpath sha512sum source_pkg rdepends tmproot tmppkgroot update_default
         local pkg_cas_file pkg_cas_root
         local pkg_locations=()
         local name=${name##*/}
@@ -120,11 +120,13 @@ function torcx_package() {
         # Install the meta-package and its direct dependencies.
         for deppkg in "=${pkg}" $(torcx_dependencies "${pkg}")
         do
-                # The first file in an app-torcx package is, by convention,
-                # considered the source package.
-                [ -z "${source_pkg}" ] && source_pkg="${deppkg#=}"
                 torcx_build "${tmproot}" "${deppkg}"
         done
+
+	# by convention, the first dependency in a torcx package is the primary
+	# source package
+	rdepends=($(torcx_dependencies "${pkg}"))
+	source_pkg="${rdepends[0]#=}"
 
         # Pluck out shared libraries and SONAME links.
         sudo mv "${tmproot}"/{lib,tmplib}
@@ -199,7 +201,9 @@ function torcx_package() {
                 update_default=true
                 pkg_locations+=("/usr/share/torcx/store/${name}:${version}.torcx.tgz")
         fi
-        # TODO: add upload bucket path to pkg_locations
+	if [[ "${FLAGS_upload}" -eq ${FLAGS_TRUE} ]]; then
+		pkg_locations+=("$(download_tectonic_torcx_url "pkg/${BOARD}/${name}/${digest}/${name}:${version}.torcx.tgz")")
+	fi
         torcx_manifest::add_pkg "${manifest_path}" \
             "${name}" \
             "${version}" \
@@ -236,20 +240,19 @@ set_build_symlinks latest "${FLAGS_group}-latest"
 
 # Upload the pkgs referenced by this manifest
 for pkg in $(torcx_manifest::get_pkg_names "${manifest_path}"); do
-        pkg_name="${pkgs[0]}"
         for digest in $(torcx_manifest::get_digests "${manifest_path}" "${pkg}"); do
             sign_and_upload_files \
                 'torcx pkg' \
-                "${UPLOAD_ROOT}/torcx/pkg/${BOARD}/${pkg_name}/${digest}" \
+                "${TORCX_UPLOAD_ROOT}/pkg/${BOARD}/${pkg}/${digest}" \
                 "" \
-                "${TORCX_CAS_ROOT}/${pkg_name}/${digest}"/*.torcx.tgz
+                "${TORCX_CAS_ROOT}/${pkg}/${digest}"/*.torcx.tgz
       done
 done
 
 # Upload the manifest
 sign_and_upload_files \
     'torcx manifest' \
-    "${UPLOAD_ROOT}/torcx/manifests/${BOARD}/${COREOS_VERSION}" \
+    "${TORCX_UPLOAD_ROOT}/manifests/${BOARD}/${COREOS_VERSION}" \
     "" \
     "${manifest_path}"
 

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -15,7 +15,7 @@ assert_not_root_user
 DEFINE_string board "${DEFAULT_BOARD}" \
   "The board to build packages for."
 DEFINE_string output_root "${DEFAULT_BUILD_ROOT}/torcx" \
-  "Directory in which to place torcx stores (named by board/version)"
+  "Directory in which to place torcx stores and manifests (named by board/version)"
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
@@ -50,10 +50,13 @@ switch_to_strict_mode
 # Initialize upload options
 check_gsutil_opts
 
+TORCX_CAS_ROOT="${FLAGS_output_root}/pkgs/${BOARD}"
+
 # Define BUILD_DIR and set_build_symlinks.
 . "${BUILD_LIBRARY_DIR}/toolchain_util.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/board_options.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/build_image_util.sh" || exit 1
+. "${BUILD_LIBRARY_DIR}/torcx_manifest.sh" || exit 1
 
 # Print the first level of runtime dependencies for a torcx meta-package.
 function torcx_dependencies() (
@@ -90,14 +93,22 @@ function torcx_package() {
         local pkg="app-torcx/${1##*/}"
         local name=${pkg%-[0-9]*}
         local version=${pkg:${#name}+1}
-        local deppkg file rpath tmproot
-        name=${name##*/}
-        version=${version%%-r*}
+        local manifest_path="${2}"
+        local type="${3}"
+        local deppkg digest file rpath sha512sum source_pkg tmproot tmppkgroot update_default
+        local pkg_cas_file pkg_cas_root
+        local pkg_locations=()
+        local name=${name##*/}
+        local version=${version%%-r*}
 
         # Set up the base package layout to dump everything into /bin and /lib.
+        # tmproot is what the packages are installed into.
+        # A subset of the files from tmproot are then moved into tmppkgroot,
+        # which is then archived and uploaded.
         tmproot=$(sudo mktemp --tmpdir="${BUILD_DIR}" -d)
-        trap "sudo rm -rf '${tmproot}'" EXIT RETURN
-        sudo chmod 0755 "${tmproot}"
+        tmppkgroot=$(sudo mktemp --tmpdir="${BUILD_DIR}" -d)
+        trap "sudo rm -rf '${tmproot}' '${tmppkgroot}'" EXIT RETURN
+        sudo chmod 0755 "${tmproot}" "${tmppkgroot}"
         sudo mkdir -p "${tmproot}"/{.torcx,bin,lib,usr}
         sudo ln -fns ../bin "${tmproot}/usr/bin"
         sudo ln -fns ../lib "${tmproot}/usr/lib"
@@ -109,6 +120,9 @@ function torcx_package() {
         # Install the meta-package and its direct dependencies.
         for deppkg in "=${pkg}" $(torcx_dependencies "${pkg}")
         do
+                # The first file in an app-torcx package is, by convention,
+                # considered the source package.
+                [ -z "${source_pkg}" ] && source_pkg="${deppkg#=}"
                 torcx_build "${tmproot}" "${deppkg}"
         done
 
@@ -151,10 +165,50 @@ function torcx_package() {
                 :  # Set $? to 0 or the pipeline fails and -e quits.
         done
 
-        # Package the installed files.
-        file="${BUILD_DIR}/${name}:${version}.torcx.tgz"
-        tar --force-local -C "${tmproot}" -czf "${file}" .torcx bin lib
-        ln -fns "${file##*/}" "${BUILD_DIR}/${name}:com.coreos.cl.torcx.tgz"
+        # Move anything we plan to package to its root
+        sudo mv "${tmproot}"/{.torcx,bin,lib} "${tmppkgroot}"
+
+        # Create a reproducible digest by which this package will be uploaded
+        # and referred
+        digest=$(casync \
+                        --digest=sha512-256 \
+                        --without=selinux \
+                        --with=flag-noatime \
+                        --what=directory \
+                        digest "${tmppkgroot}")
+
+        pkg_cas_root="${TORCX_CAS_ROOT}/${name}/${digest}"
+        pkg_cas_file="${pkg_cas_root}/${name}:${version}.torcx.tgz"
+
+        # Create the cas store if it doesn't exist
+        if [[ ! -d "${pkg_cas_root}" ]]; then
+                mkdir -p "${TORCX_CAS_ROOT}/${name}"
+                # Package the installed files.
+                tmpcas="${BUILD_DIR}/${digest}"
+                mkdir -p "${tmpcas}"
+                tmpfile="${tmpcas}/${name}:${version}.torcx.tgz"
+                tar --force-local -C "${tmppkgroot}" -czf "${tmpfile}" .
+                # atomically move the whole directory in place from a tmp locatoin
+                mv "${tmpcas}" "${pkg_cas_root}"
+        fi
+        [[ -f "${pkg_cas_file}" ]] || die "${pkg_cas_file} should exist but didn't"
+        sha512sum=$(sha512sum "${pkg_cas_file}" | awk '{print $1}')
+
+        update_default=false
+        if [[ "${type}" == "default" ]]; then
+                update_default=true
+                pkg_locations+=("/usr/share/torcx/store/${name}:${version}.torcx.tgz")
+        fi
+        # TODO: add upload bucket path to pkg_locations
+        torcx_manifest::add_pkg "${manifest_path}" \
+            "${name}" \
+            "${version}" \
+            "sha512-${sha512sum}" \
+            "${digest}" \
+            "${source_pkg}" \
+            "${update_default}" \
+            "${pkg_locations[@]}"
+
         trap - EXIT
 }
 
@@ -166,13 +220,37 @@ DEFAULT_IMAGES=(
         =app-torcx/docker-17.06
 )
 
+# Tihs list contains extra images which will be uploaded and included in the
+# generated manifest, but won't be included in the vendor store.
+EXTRA_IMAGES=(
+        =app-torcx/docker-1.12
+)
+
 mkdir -p "${BUILD_DIR}"
-for pkg in "${@:-${DEFAULT_IMAGES[@]}}" ; do torcx_package "${pkg#=}" ; done
+manifest_path="${BUILD_DIR}/torcx_manifest.json"
+torcx_manifest::create_empty "${manifest_path}"
+for pkg in "${@:-${DEFAULT_IMAGES[@]}}" ; do torcx_package "${pkg#=}" "${manifest_path}" "default" ; done
+for pkg in "${EXTRA_IMAGES[@]}" ; do torcx_package "${pkg#=}" "${manifest_path}" "extra" ; done
 
 set_build_symlinks latest "${FLAGS_group}-latest"
 
+# Upload the pkgs referenced by this manifest
+for pkg in $(torcx_manifest::get_pkg_names "${manifest_path}"); do
+        pkg_name="${pkgs[0]}"
+        for digest in $(torcx_manifest::get_digests "${manifest_path}" "${pkg}"); do
+            sign_and_upload_files \
+                'torcx pkg' \
+                "${UPLOAD_ROOT}/torcx/pkg/${BOARD}/${pkg_name}/${digest}" \
+                "" \
+                "${TORCX_CAS_ROOT}/${pkg_name}/${digest}"/*.torcx.tgz
+      done
+done
+
+# Upload the manifest
 sign_and_upload_files \
-    'torcx images' \
-    "${UPLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION}" \
-    torcx/ \
-    "${BUILD_DIR}"/*.torcx.tgz
+    'torcx manifest' \
+    "${UPLOAD_ROOT}/torcx/manifests/${BOARD}/${COREOS_VERSION}" \
+    "" \
+    "${manifest_path}"
+
+# vim: tabstop=8 softtabstop=4 shiftwidth=8 expandtab

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -40,7 +40,7 @@ else
         script set_official --board="${BOARD}" --noofficial
 fi
 
-# Retrieve this version's torcx vendor store.
+# Retrieve this version's torcx vendor store and all referenced packages.
 enter gsutil cp -r \
     "${DOWNLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION}/torcx" \
     /mnt/host/source/


### PR DESCRIPTION


- [x] `./build_packages` produces manifest and cas pkgs
- [x] `./build_packages --upload` does the right thing for developers
- [ ] `./build_image` on dev machines includes torcx packages based on a manifest correctly
- [ ] `./jenkins/images.sh` correctly populates torcx store and can `build_image`
- [ ] `plume pre-release` 'releases' cas pkgs correctly
- [ ] `kola` accepts a 'torcx manifest' path to test a manifest prior to signing / upload
- [ ] signing scripts for download/signing/uploading the torcx manifest