### PR TITLE
build_library: rename oracle_oci image to oracle_oci_qcow

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -12,7 +12,7 @@ VALID_IMG_TYPES=(
     iso
     openstack
     openstack_mini
-    oracle_oci
+    oracle_oci_qcow
     qemu
     qemu_uefi
     qemu_uefi_secure
@@ -244,8 +244,8 @@ IMG_gce_OEM_PACKAGE=oem-gce
 IMG_gce_OEM_ACI=gce
 
 ## Oracle OCI
-IMG_oracle_oci_DISK_FORMAT=qcow2
-IMG_oracle_oci_OEM_PACKAGE=oem-oracle-oci
+IMG_oracle_oci_qcow_DISK_FORMAT=qcow2
+IMG_oracle_oci_qcow_OEM_PACKAGE=oem-oracle-oci
 
 ## rackspace
 IMG_rackspace_OEM_PACKAGE=oem-rackspace


### PR DESCRIPTION
Reserve the unsuffixed name for a raw image, in case we ever want to support installing to disk using `coreos-install -o` on a PXE-booted system.