### PR TITLE
build_library: Add torcx source packages to the package list

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -259,6 +259,11 @@ image_packages() {
             query_available_package "${pkg}"
         done < "${profile}/package.provided"
     fi
+
+    # Include source packages of all torcx images installed on disk.
+    [ -z "${FLAGS_torcx_manifest}" ] ||
+    torcx_manifest::sources_on_disk "${FLAGS_torcx_manifest}" |
+    while read pkg ; do query_available_package "${pkg}" ; done
 }
 
 # Generate a list of installed packages in the format:

--- a/build_library/torcx_manifest.sh
+++ b/build_library/torcx_manifest.sh
@@ -127,3 +127,9 @@ function torcx_manifest::default_version() {
   local name="${2}"
   jq -r ".value.packages[] | select(.name == \"${name}\").defaultVersion" < "${file}"
 }
+
+# sources_on_disk returns the list of source packages of all torcx images installed on disk
+function torcx_manifest::sources_on_disk() {
+  local file="${1}"
+  jq -r ".value.packages[].versions[] | select(.locations[].path).sourcePackage" < "${file}"
+}


### PR DESCRIPTION
This includes the source package of all torcx packages that are installed on disk, including cases where multiple versions of the same package are available.