### PR TITLE
build_torcx_store: default to docker 1.12 for 1520

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -218,13 +218,13 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-17.06
+        =app-torcx/docker-1.12
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
-        =app-torcx/docker-1.12
+        =app-torcx/docker-17.06
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
For coreos/bugs#1930.