### PR TITLE
build_library/torcx_manifest: omit newlines

### DIFF
--- a/build_library/torcx_manifest.sh
+++ b/build_library/torcx_manifest.sh
@@ -96,7 +96,7 @@ function torcx_manifest::local_store_path() {
   local file="${1}"
   local name="${2}"
   local version="${3}"
-  jq -r ".value.packages[] | select(.name == \"${name}\") | .versions[] | select(.version == \"${version}\") | .locations[].path" < "${file}"
+  jq -j -r ".value.packages[] | select(.name == \"${name}\") | .versions[] | select(.version == \"${version}\") | .locations[].path" < "${file}"
 }
 
 # get_digest returns the cas digest for a given package version
@@ -104,7 +104,7 @@ function torcx_manifest::get_digest() {
   local file="${1}"
   local name="${2}"
   local version="${3}"
-  jq -r ".value.packages[] | select(.name == \"${name}\") | .versions[] | select(.version == \"${version}\") | .casDigest" < "${file}"
+  jq -j -r ".value.packages[] | select(.name == \"${name}\") | .versions[] | select(.version == \"${version}\") | .casDigest" < "${file}"
 }
 
 # get_digests returns the list of digests for a given package. 
@@ -125,5 +125,5 @@ function torcx_manifest::get_versions() {
 function torcx_manifest::default_version() {
   local file="${1}"
   local name="${2}"
-  jq -r ".value.packages[] | select(.name == \"${name}\").defaultVersion" < "${file}"
+  jq -j -r ".value.packages[] | select(.name == \"${name}\").defaultVersion" < "${file}"
 }


### PR DESCRIPTION
Omit the newline for each function that returns only a single value.

This does not change each function that returns multiple values as those
are expected, by the caller, to be newline delimited values.

Before this change, the consumer of 'local_store_path' specifically
ended up with bad behavior of including a newline in the on-disk
filename.

Fortunately, the symlink included that newline as well, so it didn't
*break* things, but it did mean the filepath differed from the one
declared in the manifest slightly.

Pending a full `./build_package && ./bulid_image` cycle to verify this didn't break anything obvious.