### PR TITLE
build_library: Filter out null paths in torcx manifests

### DIFF
--- a/build_library/torcx_manifest.sh
+++ b/build_library/torcx_manifest.sh
@@ -96,7 +96,7 @@ function torcx_manifest::local_store_path() {
   local file="${1}"
   local name="${2}"
   local version="${3}"
-  jq -r ".value.packages[] | select(.name == \"${name}\") | .versions[] | select(.version == \"${version}\") | .locations[].path" < "${file}"
+  jq -r ".value.packages[] | select(.name == \"${name}\") | .versions[] | select(.version == \"${version}\") | .locations[] | select(.path).path" < "${file}"
 }
 
 # get_digest returns the cas digest for a given package version


### PR DESCRIPTION
This avoids odd "null" lines appearing in torcx image names.