### PR TITLE
update_chroot: Avoid a portage crash while upgrading binutils

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -194,7 +194,9 @@ get_cross_pkgs() {
 # Get portage arguments restricting toolchains to binary packages only.
 get_binonly_args() {
     local pkgs=( "${TOOLCHAIN_PKGS[@]}" $(get_cross_pkgs "$@") )
-    echo "${pkgs[@]/#/--useoldpkg-atoms=}" "${pkgs[@]/#/--rebuild-exclude=}"
+    # XXX: Revert this binutils change after stable > 1535.
+    local tmppkgs=( ${pkgs[*]##*/binutils} )
+    echo "${tmppkgs[@]/#/--useoldpkg-atoms=}" "${pkgs[@]/#/--rebuild-exclude=}"
 }
 
 ### Toolchain building utilities ###

--- a/update_chroot
+++ b/update_chroot
@@ -241,6 +241,9 @@ sudo -E ${EMERGE_CMD} "${EMERGE_FLAGS[@]}" \
     coreos-devel/sdk-depends world
 
 info "Removing obsolete packages"
+# XXX: Remove these binutils lines after stable > 1535.
+cats=( '<=sys-devel' "${BOARD_CHOSTS[@]/#/<=cross-}" )
+sudo -E emerge --quiet --unmerge "${cats[@]/%//binutils-2.28.0}" 2>/dev/null || :
 sudo -E ${EMERGE_CMD} --quiet --depclean @unavailable
 
 if portageq list_preserved_libs / >/dev/null; then


### PR DESCRIPTION
This omits the toolchain packages' version-pinning flag for the binutils package while it is being upgraded.  It also removes older versions installed in parallel that cause unwanted rebuilds.

When stable has the upgraded version, this can be reverted.

Part of coreos/portage-stable#586.