### PR TITLE
jenkins/formats-amd64: add oracle_oci_qcow

### DIFF
--- a/jenkins/formats-amd64-usr.txt
+++ b/jenkins/formats-amd64-usr.txt
@@ -16,6 +16,7 @@ hyperv
 niftycloud
 openstack
 openstack_mini
+oracle_oci_qcow
 packet
 parallels
 rackspace


### PR DESCRIPTION
Part of https://github.com/coreos/bugs/issues/2035#issuecomment-331966047

cc @bgilbert 