### PR TITLE
Update Docker to 17.09 and add 17.03 in alpha

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -224,7 +224,9 @@ DEFAULT_IMAGES=(
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
-EXTRA_IMAGES=()
+EXTRA_IMAGES=(
+	=app-torcx/docker-17.03
+)
 
 mkdir -p "${BUILD_DIR}"
 manifest_path="${BUILD_DIR}/torcx_manifest.json"

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -219,7 +219,7 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-17.06
+        =app-torcx/docker-17.09
 )
 
 # This list contains extra images which will be uploaded and included in the


### PR DESCRIPTION
Backports #759

Depends on coreos/coreos-overlay#2798

This still builds 1.12 as the optional on-disk version in case we have to build an alpha point release.  The versions still need to be swapped during promotion.