### PR TITLE
build_torcx_store: Set Docker 1.12 as the default image

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -218,8 +218,8 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-1.12
         =app-torcx/docker-17.09
+        =app-torcx/docker-1.12
 )
 
 # This list contains extra images which will be uploaded and included in the


### PR DESCRIPTION
coreos/bugs#1930