### PR TITLE
dev_image_util: hardcode correct portage binhost

### DIFF
--- a/build_library/dev_image_util.sh
+++ b/build_library/dev_image_util.sh
@@ -25,7 +25,8 @@ PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
 PORTDIR="/var/lib/portage/portage-stable"
 PORTDIR_OVERLAY="/var/lib/portage/coreos-overlay"
-PORTAGE_BINHOST="$(get_board_binhost $BOARD $COREOS_VERSION_ID | sed 's/^gs:/http:/')"
+PORTAGE_BINHOST="http://builds.developer.core-os.net/boards/${BOARD}/${COREOS_VERSION_ID}/pkgs/
+http://builds.developer.core-os.net/boards/${BOARD}/${COREOS_VERSION_ID}/toolchain/"
 EOF
 
 sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF


### PR DESCRIPTION
We already hardcode similar urls a bit below (the sync-uri).

Not hardcoding the binhost results in an incorrect value during
embargoed build uploads.