### PR TITLE
build_library: Whitelist the Go 1.9 GLSA

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -5,6 +5,7 @@
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
 	201709-02 # updating binutils breaks amd64 Linux uncompression
+	201710-23 # we handle Go differently; drop when 1.9 builds everything
 )
 
 glsa_image() {


### PR DESCRIPTION
Part of coreos/portage-stable#590