### PR TITLE
build_torcx_store: Upgrade to Docker 17.10 on disk

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -219,13 +219,14 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-17.09
+        =app-torcx/docker-17.10
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
 	=app-torcx/docker-17.03
+	=app-torcx/docker-17.09
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
Part of coreos/coreos-overlay#2851