### PR TITLE
build_library: upload kernel config as release artifact

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -425,6 +425,7 @@ finish_image() {
   local pcr_policy="$6"
   local image_grub="$7"
   local image_shim="$8"
+  local image_kconfig="$9"
 
   local install_grub=0
   local disk_img="${BUILD_DIR}/${image_name}"
@@ -498,6 +499,11 @@ EOF
     sudo cp "${FLAGS_developer_data}" "${root_fs_dir}/${data_path}"
     systemd_enable "${root_fs_dir}" system-config.target \
         "system-cloudinit@.service" "system-cloudinit@${unit_path}.service"
+  fi
+
+  if [[ -n "${image_kconfig}" ]]; then
+    cp "${root_fs_dir}/usr/boot/config" \
+        "${BUILD_DIR}/${image_kconfig}"
   fi
 
   write_contents "${root_fs_dir}" "${BUILD_DIR}/${image_contents}"

--- a/build_library/modify_image_util.sh
+++ b/build_library/modify_image_util.sh
@@ -63,6 +63,7 @@ start_modify_image() {
         "${pcr_data}"
         "${production_prefix}_contents.txt"
         "${production_prefix}_packages.txt"
+        "${production_prefix}_kernel_config.txt"
         "${COREOS_DEVELOPER_CONTAINER_NAME}"
         "${container_prefix}_contents.txt"
         "${container_prefix}_packages.txt"

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -66,6 +66,7 @@ create_prod_image() {
   local image_contents="${image_name%.bin}_contents.txt"
   local image_packages="${image_name%.bin}_packages.txt"
   local image_licenses="${image_name%.bin}_licenses.json"
+  local image_kconfig="${image_name%.bin}_kernel_config.txt"
   local image_kernel="${image_name%.bin}.vmlinuz"
   local image_pcr_policy="${image_name%.bin}_pcr_policy.zip"
   local image_grub="${image_name%.bin}.grub"
@@ -126,7 +127,8 @@ EOF
       "${image_kernel}" \
       "${image_pcr_policy}" \
       "${image_grub}" \
-      "${image_shim}"
+      "${image_shim}" \
+      "${image_kconfig}"
 
   # Upload
   local to_upload=(
@@ -137,6 +139,7 @@ EOF
     "${BUILD_DIR}/${image_kernel}"
     "${BUILD_DIR}/${image_pcr_policy}"
     "${BUILD_DIR}/${image_grub}"
+    "${BUILD_DIR}/${image_kconfig}"
   )
   # FIXME(bgilbert): no shim on arm64
   if [[ -f "${BUILD_DIR}/${image_shim}" ]]; then


### PR DESCRIPTION
It's useful to have this information available without starting an image or digging up a binpkg.