### PR TITLE
disk_util: use FAT32 on ESP

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -423,6 +423,9 @@ def FormatFat(part, device):
   cmd = ['mkfs.vfat']
   if 'fs_label' in part:
     cmd += ['-n', part['fs_label']]
+  if part['type'] == 'efi':
+    # ESP is FAT32 irrespective of size
+    cmd += ['-F', '32']
   Sudo(cmd + [device, vfat_blocks], stdout_null=True)
 
 


### PR DESCRIPTION
`mkfs.vfat` was defaulting to FAT16 based on the size of the partition. The UEFI spec (2.7 errata A, section 13.3) implies that only FAT32 is necessarily supported on the ESP, and we've received a report of hardware that doesn't recognize FAT16.

Addresses https://github.com/coreos/bugs/issues/2246.