### PR TITLE
*: make prod images default

### DIFF
--- a/build_image
+++ b/build_image
@@ -82,7 +82,7 @@ DEFINE_string version "" \
 # Parse command line.
 FLAGS "$@" || exit 1
 
-eval set -- "${FLAGS_ARGV:-dev}"
+eval set -- "${FLAGS_ARGV:-prod}"
 
 # Only now can we die on error.  shflags functions leak non-zero error codes,
 # so will die prematurely if 'switch_to_strict_mode' is specified before now.
@@ -234,11 +234,11 @@ EOF
 # Print out the images we generated.
 if [[ "${PROD_IMAGE}" -eq 1 ]]; then
   echo "CoreOS Production image created as ${COREOS_PRODUCTION_IMAGE_NAME}"
-  print_image_to_vm "prod"
+  print_image_to_vm
 fi
 if [[ "${DEV_IMAGE}" -eq 1 ]]; then
   echo "Developer image created as ${COREOS_DEVELOPER_IMAGE_NAME}"
-  print_image_to_vm
+  print_image_to_vm dev
 fi
 
 command_completed

--- a/build_library/modify_image_util.sh
+++ b/build_library/modify_image_util.sh
@@ -95,7 +95,7 @@ finish_modify_image() {
     info "Done. Updated image is in ${BUILD_DIR}"
     cat << EOF
 To convert it to a virtual machine image, use:
-  ./image_to_vm.sh --from=${OUTSIDE_OUTPUT_DIR} --board=${BOARD} --prod_image
+  ./image_to_vm.sh --from=${OUTSIDE_OUTPUT_DIR} --board=${BOARD}
 
 The default type is qemu, see ./image_to_vm.sh --help for other options.
 EOF

--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -36,8 +36,8 @@ DEFINE_string disk_layout "" \
   "The disk layout type to use for this image."
 DEFINE_integer mem "${DEFAULT_MEM}" \
   "Memory size for the vm config in MBs."
-DEFINE_boolean prod_image "${FLAGS_FALSE}" \
-  "Use the production image instead of the default developer image."
+DEFINE_boolean dev_image "${FLAGS_FALSE}" \
+  "Use the development image instead of the default production image."
 DEFINE_string to "" \
   "Destination folder for VM output file(s)"
 DEFINE_string oem_pkg "" \
@@ -107,21 +107,19 @@ if [ -f "${FLAGS_from}/version.txt" ]; then
     COREOS_VERSION_STRING="${COREOS_VERSION}"
 fi
 
-if [ ${FLAGS_prod_image} -eq ${FLAGS_TRUE} ]; then
-  set_vm_paths "${FLAGS_from}" "${FLAGS_to}" "${COREOS_PRODUCTION_IMAGE_NAME}"
-else
-  # Use the standard image
+if [ ${FLAGS_dev_image} -eq ${FLAGS_TRUE} ]; then
   set_vm_paths "${FLAGS_from}" "${FLAGS_to}" "${COREOS_DEVELOPER_IMAGE_NAME}"
+  if [[ "${FLAGS_disk_layout}" == "" ]]; then
+    FLAGS_disk_layout=devel
+  fi
+else
+  set_vm_paths "${FLAGS_from}" "${FLAGS_to}" "${COREOS_PRODUCTION_IMAGE_NAME}"
 fi
 
 # Make sure things are cleaned up on failure
 trap vm_cleanup EXIT
 
 fix_mtab
-
-if [[ "${FLAGS_prod_image}" -eq "${FLAGS_FALSE}" && "${FLAGS_disk_layout}" == "" ]]; then
-    FLAGS_disk_layout=devel
-fi
 
 # Setup new (raw) image, possibly resizing filesystems
 setup_disk_image "${FLAGS_disk_layout}"

--- a/jenkins/vm.sh
+++ b/jenkins/vm.sh
@@ -45,7 +45,6 @@ enter lbunzip2 -k -f "/mnt/host/source/${img}.bz2"
 script image_to_vm.sh \
     --board="${BOARD}" \
     --format="${FORMAT}" \
-    --prod_image \
     --getbinpkg \
     --getbinpkgver="${COREOS_VERSION}" \
     --from=/mnt/host/source/src \


### PR DESCRIPTION
Make prod images default instead of dev images. Additionally, clean up some of the flag logic around the --dev_image flag in image_to_vm.sh

This should probably wait until after 1632.0.0 because it will almost certainly break some jenkins jobs.

Edit: waiting until after 1646.0.0

@bgilbert 