### PR TITLE
Revert "disk_util: use FAT32 on ESP"

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -423,9 +423,6 @@ def FormatFat(part, device):
   cmd = ['mkfs.vfat']
   if 'fs_label' in part:
     cmd += ['-n', part['fs_label']]
-  if part['type'] == 'efi':
-    # ESP is FAT32 irrespective of size
-    cmd += ['-F', '32']
   Sudo(cmd + [device, vfat_blocks], stdout_null=True)
 
 


### PR DESCRIPTION
This reverts commit 7f058d61a10384ca81c88245c4ff80c08f89ad6b.

Reverting because of bug 2284 [1] where grub will sometimes fail due to
memory corruption. This is _not_ the cause of the bug, and the bug can
even be reproduced with this reversion, but it seems to occur less when
not using fat32.

[1] https://github.com/coreos/bugs/issues/2284