### PR TITLE
build_torcx_store: Make the LTS Docker CE version the default

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -225,14 +225,13 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-17.11
+        =app-torcx/docker-17.09
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
 	=app-torcx/docker-17.03
-	=app-torcx/docker-17.09
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
Drop the edge version for the beta channel.