### PR TITLE
build_torcx_store: Update Docker's default and LTS images

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -225,14 +225,14 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-17.12
+        =app-torcx/docker-18.01
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
 	=app-torcx/docker-17.03
-	=app-torcx/docker-17.09
+	=app-torcx/docker-17.12
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
The default version is updated from 17.12 to 18.01, and the LTS version is updated from 17.09 to 17.12.

Part of coreos/coreos-overlay#3005