### PR TITLE
build_torcx_store: Drop the Docker 17.09 image

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -232,7 +232,6 @@ DEFAULT_IMAGES=(
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
 	=app-torcx/docker-17.03
-	=app-torcx/docker-17.09
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
In preparation for the beta channel, we'd normally set the default Docker image to the LTS version and drop the extra edge version.  Since branching, the alpha's default 17.12 image has become the LTS version, so just drop the extra 17.09 image for consistency.