### PR TITLE
enter_chroot: Drop special locale-gen handling

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -194,8 +194,8 @@ get_cross_pkgs() {
 # Get portage arguments restricting toolchains to binary packages only.
 get_binonly_args() {
     local pkgs=( "${TOOLCHAIN_PKGS[@]}" $(get_cross_pkgs "$@") )
-    # XXX: Revert this after stable > 1632.
-    local tmppkgs=( ${pkgs[*]##*/binutils} ) ; tmppkgs=( ${tmppkgs[*]##*/gcc} )
+    # XXX: Drop this exception after stable > 1729.
+    local tmppkgs=( ${pkgs[*]##*/glibc} )
     echo "${tmppkgs[@]/#/--useoldpkg-atoms=}" "${pkgs[@]/#/--rebuild-exclude=}"
 }
 

--- a/sdk_lib/enter_chroot.sh
+++ b/sdk_lib/enter_chroot.sh
@@ -158,43 +158,6 @@ promote_api_keys() {
   fi
 }
 
-generate_locales() {
-  # Going forward the SDK will no longer include locale-gen and instead
-  # glibc will just install the full locale archive, skipping this goo.
-  [[ -x "${FLAGS_chroot}/usr/sbin/locale-gen" ]] || return 0
-
-  # Make sure user's requested locales are available
-  # http://crosbug.com/19139
-  # And make sure en_US{,.UTF-8} are always available as
-  # that what buildbot forces internally
-  local l locales gen_locales=()
-
-  locales=$(printf '%s\n' en_US en_US.UTF-8 ${LANG} \
-    $LC_{ADDRESS,ALL,COLLATE,CTYPE,IDENTIFICATION,MEASUREMENT,MESSAGES} \
-    $LC_{MONETARY,NAME,NUMERIC,PAPER,TELEPHONE,TIME} | \
-    sort -u | sed '/^C$/d')
-  for l in ${locales}; do
-    if [[ ${l} == *.* ]]; then
-      enc=${l#*.}
-    else
-      enc="ISO-8859-1"
-    fi
-    case $(echo ${enc//-} | tr '[:upper:]' '[:lower:]') in
-    utf8) enc="UTF-8";;
-    esac
-    gen_locales+=("${l} ${enc}")
-  done
-  if [[ ${#gen_locales[@]} -gt 0 ]] ; then
-    # Force LC_ALL=C to workaround slow string parsing in bash
-    # with long multibyte strings.  Newer setups have this fixed,
-    # but locale-gen doesn't need to be run in any locale in the
-    # first place, so just go with C to keep it fast.
-    chroot "${FLAGS_chroot}" /usr/bin/env \
-      PATH="/usr/sbin:/usr/bin:/sbin:/bin" LC_ALL=C \
-      locale-gen -q -u -G "$(printf '%s\n' "${gen_locales[@]}")"
-  fi
-}
-
 setup_env() {
   (
     flock 200
@@ -234,9 +197,6 @@ setup_env() {
     fi
     mkdir -p "${MOUNTED_PATH}/run/user/${SUDO_UID}"
     chown ${SUDO_UID}:${SUDO_GID} "${MOUNTED_PATH}/run/user/${SUDO_UID}"
-
-    # Do this early as it's slow and only needs basic mounts (above).
-    generate_locales &
 
     mkdir -p "${FLAGS_chroot}/${CHROOT_TRUNK_DIR}"
     setup_mount "${FLAGS_trunk}" "--rbind" "${CHROOT_TRUNK_DIR}"

--- a/update_chroot
+++ b/update_chroot
@@ -241,9 +241,6 @@ sudo -E ${EMERGE_CMD} "${EMERGE_FLAGS[@]}" \
     coreos-devel/sdk-depends world
 
 info "Removing obsolete packages"
-# XXX: Remove these next two lines after stable > 1632.
-cats=( '<=sys-devel' "${BOARD_CHOSTS[@]/#/<=cross-}" )
-sudo -E emerge --quiet --unmerge "${cats[@]/%//binutils-2.29.0}" "${cats[@]/%//gcc-7.2.0}" 2>/dev/null || :
 sudo -E ${EMERGE_CMD} --quiet --depclean @unavailable
 
 if portageq list_preserved_libs / >/dev/null; then


### PR DESCRIPTION
This addresses errors when entering the SDK.

Part of coreos/coreos-overlay#3161