### PR TITLE
update_chroot: Drop obsolete GCC versions, older than 7.3.0

### DIFF
--- a/update_chroot
+++ b/update_chroot
@@ -243,7 +243,7 @@ sudo -E ${EMERGE_CMD} "${EMERGE_FLAGS[@]}" \
 info "Removing obsolete packages"
 # XXX: Remove these next two lines after stable > 1632.
 cats=( '<=sys-devel' "${BOARD_CHOSTS[@]/#/<=cross-}" )
-sudo -E emerge --quiet --unmerge "${cats[@]/%//binutils-2.29.0}" "${cats[@]/%//gcc-6.3.0}" 2>/dev/null || :
+sudo -E emerge --quiet --unmerge "${cats[@]/%//binutils-2.29.0}" "${cats[@]/%//gcc-7.2.0}" 2>/dev/null || :
 sudo -E ${EMERGE_CMD} --quiet --depclean @unavailable
 
 if portageq list_preserved_libs / >/dev/null; then


### PR DESCRIPTION
Part of coreos/coreos-overlay#3059