### PR TITLE
catalyst: Disable ccache

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -58,7 +58,7 @@ cat <<EOF
 contents="auto"
 digests="md5 sha1 sha512 whirlpool"
 hash_function="crc32"
-options="ccache pkgcache"
+options="pkgcache"
 sharedir="/usr/lib/catalyst"
 storedir="$CATALYST_ROOT"
 distdir="$DISTDIR"


### PR DESCRIPTION
It provides no value when it works, and it's randomly causing failures to build toolchains due to permissions problems after certain releases.  This also requires taking it out of FEATURES in the portage profile (which is the SDK profile by default).

Test Jenkins runs of SDK and toolchains jobs both ran in the same time as with ccache enabled.