### PR TITLE
build_library: Whitelist the new Go 1.9 GLSA

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -5,6 +5,7 @@
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
 	201710-23 # we handle Go differently; drop when 1.9 builds everything
+	201803-03 # same as above, drop when all Go < 1.9 packages are gone
 )
 
 glsa_image() {


### PR DESCRIPTION
Part of coreos/portage-stable#649