### PR TITLE
Fix a bug when setting VM_CDROM in qemu template

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -198,7 +198,8 @@ if [ -n "${VM_UUID}" ]; then
 fi
 
 if [ -n "${VM_CDROM}" ]; then
-    set -- -cdrom "${SCRIPT_DIR}/${VM_CDROM}" "$@"
+    set -- -boot order=d \
+	-drive file="${SCRIPT_DIR}/${VM_CDROM}",media=cdrom,format=raw "$@"
 fi
 
 if [ -n "${VM_PFLASH_RO}" ] && [ -n "${VM_PFLASH_RW}" ]; then


### PR DESCRIPTION
Fix a bug in the qemu template, which is used for generating `coreos_production_qemu.sh` or similar. Setting `$VM_CDROM` in the qemu script does not work as expected when installing Container Linux from the given bootable CDROM image. That's probably because qemu-system-x86_64 expects another boot option `-boot order=d` to be able to boot from the given CDROM drive. Let's specify a `-boot` as well as `-drive` option for the given CDROM drive.
