### PR TITLE
Revert "Revert "disk_util: use FAT32 on ESP""

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -423,6 +423,9 @@ def FormatFat(part, device):
   cmd = ['mkfs.vfat']
   if 'fs_label' in part:
     cmd += ['-n', part['fs_label']]
+  if part['type'] == 'efi':
+    # ESP is FAT32 irrespective of size
+    cmd += ['-F', '32']
   Sudo(cmd + [device, vfat_blocks], stdout_null=True)
 
 


### PR DESCRIPTION
FAT32 seemed to aggravate https://github.com/coreos/bugs/issues/2284, but now that that issue has been addressed, we can return to the correct filesystem type.

This reverts #779 and fixes coreos/bugs#2246.