### PR TITLE
Drop Docker 17.12 for beta promotion

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -232,7 +232,6 @@ DEFAULT_IMAGES=(
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
 	=app-torcx/docker-17.03
-	=app-torcx/docker-17.12
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
We'll continue to build Docker 18.03 as the default since it's the current LTS version.  For consistency with other non-alpha releases, drop the unused extra image (the previous LTS 17.12).