### PR TITLE
create-basic-configdrive: update etcd v2 to etcd v3

### DIFF
--- a/contrib/create-basic-configdrive
+++ b/contrib/create-basic-configdrive
@@ -26,7 +26,7 @@ This tool creates a basic config-drive ISO image.
 CLOUD_CONFIG="#cloud-config
 
 coreos:
-  etcd2:
+  etcd-member:
     name: <ETCD_NAME>
     advertise-client-urls: <ETCD_ADDR>
     initial-advertise-peer-urls: <ETCD_PEER_URLS>
@@ -34,7 +34,7 @@ coreos:
     listen-peer-urls: <ETCD_LISTEN_PEER_URLS>
     listen-client-urls: <ETCD_LISTEN_CLIENT_URLS>
   units:
-    - name: etcd2.service
+    - name: etcd-member.service
       command: start
     - name: fleet.service
       command: start


### PR DESCRIPTION
etcd v2 has been deprecated and is replaced with etcd v3 (etcd-member)