### PR TITLE
build_torcx_store: Set the default Docker to LTS 18.03 for beta

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -225,14 +225,13 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-18.04
+        =app-torcx/docker-18.03
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
 	=app-torcx/docker-17.03
-	=app-torcx/docker-18.03
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
Part of coreos/coreos-overlay#3226