### PR TITLE
build_library: add --unrestricted to default GRUB menuentry

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -146,7 +146,7 @@ function gptprio {
     fi
 }
 
-menuentry "CoreOS default" --id=coreos {
+menuentry "CoreOS default" --id=coreos --unrestricted {
     gptprio
     linux$suf $gptprio_kernel $gptprio_cmdline $linux_cmdline
 }


### PR DESCRIPTION
This allows booting the default entry even if GRUB authentication is configured in `/usr/share/oem/grub.cfg`.

Fixes https://github.com/coreos/bugs/issues/1597.