### PR TITLE
build_library: update VMware virtual hardware version to 11

### DIFF
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -93,7 +93,7 @@
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
         <vssd:VirtualSystemIdentifier>@@NAME@@</vssd:VirtualSystemIdentifier>
-        <vssd:VirtualSystemType>vmx-07</vssd:VirtualSystemType>
+        <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
       </System>
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
@@ -191,12 +191,12 @@
         <rasd:ResourceType>10</rasd:ResourceType>
         <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
       </Item>
-      <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
-      <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
       <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
-      <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="preset"/>
       <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="preset"/>

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -788,7 +788,7 @@ _write_vmx_conf() {
 #!/usr/bin/vmware
 .encoding = "UTF-8"
 config.version = "8"
-virtualHW.version = "7"
+virtualHW.version = "11"
 cleanShutdown = "TRUE"
 displayName = "${VM_NAME}"
 ethernet0.addressType = "generated"
@@ -822,6 +822,9 @@ pciBridge6.functions = "8"
 pciBridge7.present = "TRUE"
 pciBridge7.virtualDev = "pcieRootPort"
 pciBridge7.functions = "8"
+hpet0.present = "TRUE"
+vcpu.hotadd = "TRUE"
+mem.hotadd = "TRUE"
 EOF
     # Only upload the vmx if it won't be bundled
     if [[ -z "$(_get_vm_opt BUNDLE_FORMAT)" ]]; then


### PR DESCRIPTION
This will run on ESXi 6.0 and above, and all non-EOL versions of Fusion and Workstation.

Also enable a few useful VMX features (HPET; CPU and memory hotplug) that are added by VMware Workstation 14.1.1's Change Hardware Compatibility wizard. Correspondingly, enable CPU/memory hotplug in the OVF; omit HPET because there's no obvious way to enable it.

Fixes https://github.com/coreos/bugs/issues/1583.  Fixes https://github.com/coreos/bugs/issues/2377.

The OVA won't actually import in VMware Workstation 14 without this additional patch:
```diff
diff --git a/build_library/template_vmware.ovf b/build_library/template_vmware.ovf
index 0142bb2..769d89a 100644
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -116,7 +116,7 @@
         <rasd:Description>SCSI Controller</rasd:Description>
         <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
         <rasd:InstanceID>3</rasd:InstanceID>
-        <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
+        <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
         <rasd:ResourceType>6</rasd:ResourceType>
       </Item>
       <Item>
```

VMware Workstation supports the pvscsi controller natively; it just won't import an OVA that uses it.  I've avoided making this change in the PR so we don't penalize I/O performance on ESXi and any Workstation versions that aren't affected.