### PR TITLE
[WIP] build_torcx_store: support squashfs for ondisk addons

### DIFF
--- a/build_image
+++ b/build_image
@@ -32,7 +32,7 @@ DEFINE_string base_pkg "coreos-base/coreos" \
   "The base portage package to base the build off of (only applies to prod images)"
 DEFINE_string base_dev_pkg "coreos-base/coreos-dev" \
   "The base portage package to base the build off of (only applies to dev images)"
-DEFINE_string torcx_manifest "${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest/torcx_manifest.json" \
+DEFINE_string torcx_manifest "${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest/torcx_ondisk_manifest.json" \
   "The torcx manifest describing torcx packages for this image (or blank for none)"
 DEFINE_string torcx_root "${DEFAULT_BUILD_ROOT}/torcx" \
   "Directory in which torcx packages can be found"
@@ -91,8 +91,8 @@ switch_to_strict_mode
 check_gsutil_opts
 
 # Patch around default values not being able to depend on other flags.
-if [ "x${FLAGS_torcx_manifest}" = "x${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest/torcx_manifest.json" ]; then
-  FLAGS_torcx_manifest="${DEFAULT_BUILD_ROOT}/torcx/${FLAGS_board}/latest/torcx_manifest.json"
+if [ "x${FLAGS_torcx_manifest}" = "x${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest/torcx_ondisk_manifest.json" ]; then
+  FLAGS_torcx_manifest="${DEFAULT_BUILD_ROOT}/torcx/${FLAGS_board}/latest/torcx_ondisk_manifest.json"
 fi
 
 # If downloading packages is enabled ensure the board is configured properly.

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -438,13 +438,13 @@ finish_image() {
         local on_disk_path="$(torcx_manifest::local_store_path "${FLAGS_torcx_manifest}" "${pkg}" "${version}")"
         if [[ -n "${on_disk_path}" ]]; then
           local casDigest="$(torcx_manifest::get_digest "${FLAGS_torcx_manifest}" "${pkg}" "${version}")"
-          sudo cp "${FLAGS_torcx_root}/pkgs/${BOARD}/${pkg}/${casDigest}/${pkg}:${version}.torcx.tgz" \
+          sudo cp "${FLAGS_torcx_root}/pkgs/${BOARD}/${pkg}/${casDigest}/${pkg}:${version}.torcx.squashfs" \
             "${root_fs_dir}${on_disk_path}"
 
           if [[ "${version}" == "${default_version}" ]]; then
             # Create the default symlink for this package
             sudo ln -fns "${on_disk_path##*/}" \
-              "${root_fs_dir}/${on_disk_path%/*}/${pkg}:com.coreos.cl.torcx.tgz"
+              "${root_fs_dir}/${on_disk_path%/*}/${pkg}:com.coreos.cl.torcx.squashfs"
           fi
         fi
       done

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -176,8 +176,8 @@ function torcx_package() {
                 sudo mv "${tmproot}/usr/share" "${tmppkgroot}/usr/"
         fi
 
-        tmpfile="${BUILD_DIR}/${name}:${version}.torcx.tgz"
-        tar --force-local -C "${tmppkgroot}" -czf "${tmpfile}" .
+        tmpfile="${BUILD_DIR}/${name}:${version}.torcx.squashfs"
+	mksquashfs "${tmppkgroot}" "${tmpfile}"
         sha512sum=$(sha512sum "${tmpfile}" | awk '{print $1}')
 
         # TODO(euank): this opaque digest, if it were reproducible, could save
@@ -188,24 +188,24 @@ function torcx_package() {
         # *MUST* ensure that a given pair of (digest, sha512sum) referenced in
         # a previous torcx package remains correct.
         # Because this code, as written, clobbers existing things with the same
-        # digest (but the sha512sum of the .torcx.tgz can differ, e.g. due to ctime)
-        # that property doesn't hold.
+	# digest (but the sha512sum of the archive can differ, e.g. due to
+	# ctime) that property doesn't hold.
         # To switch this back to a reprodicble digest, we *must* never clobber
         # existing objects (and thus re-use their sha512sum here).
         digest="${sha512sum}"
 
         pkg_cas_root="${TORCX_CAS_ROOT}/${name}/${digest}"
-        pkg_cas_file="${pkg_cas_root}/${name}:${version}.torcx.tgz"
+        pkg_cas_file="${pkg_cas_root}/${name}:${version}.torcx.squashfs"
         mkdir -p "${pkg_cas_root}"
         mv "${tmpfile}" "${pkg_cas_file}"
 
         update_default=false
         if [[ "${type}" == "default" ]]; then
                 update_default=true
-                pkg_locations+=("/usr/share/torcx/store/${name}:${version}.torcx.tgz")
+                pkg_locations+=("/usr/share/torcx/store/${name}:${version}.torcx.squashfs")
         fi
         if [[ "${FLAGS_upload}" -eq ${FLAGS_TRUE} ]]; then
-                pkg_locations+=("$(download_tectonic_torcx_url "pkgs/${BOARD}/${name}/${digest}/${name}:${version}.torcx.tgz")")
+                pkg_locations+=("$(download_tectonic_torcx_url "pkgs/${BOARD}/${name}/${digest}/${name}:${version}.torcx.squashfs")")
         fi
         torcx_manifest::add_pkg "${manifest_path}" \
             "${name}" \
@@ -251,7 +251,7 @@ for pkg in $(torcx_manifest::get_pkg_names "${manifest_path}"); do
                 'torcx pkg' \
                 "${TORCX_UPLOAD_ROOT}/pkgs/${BOARD}/${pkg}/${digest}" \
                 "" \
-                "${TORCX_CAS_ROOT}/${pkg}/${digest}"/*.torcx.tgz
+                "${TORCX_CAS_ROOT}/${pkg}/${digest}"/*.torcx.squashfs
       done
 done
 

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -93,11 +93,10 @@ function torcx_package() {
         local pkg="app-torcx/${1##*/}"
         local name=${pkg%-[0-9]*}
         local version=${pkg:${#name}+1}
-        local manifest_path="${2}"
-        local type="${3}"
-        local deppkg digest file rpath sha512sum source_pkg rdepends tmproot tmppkgroot update_default
-        local pkg_cas_file pkg_cas_root
-        local pkg_locations=()
+        local remote_manifest_path="${2}"
+        local ondisk_manifest_path="${3}"
+        local type="${4}"
+        local deppkg file rpath source_pkg rdepends tmproot tmppkgroot
         local name=${name##*/}
         local version=${version%%-r*}
 
@@ -176,8 +175,35 @@ function torcx_package() {
                 sudo mv "${tmproot}/usr/share" "${tmppkgroot}/usr/"
         fi
 
-        tmpfile="${BUILD_DIR}/${name}:${version}.torcx.squashfs"
-	mksquashfs "${tmppkgroot}" "${tmpfile}"
+        torcx_package_rootfs "${name}" "${version}" "${source_pkg}" "${tmppkgroot}" "tgz" "${type}" "remote" "${remote_manifest_path}"
+        if [[ -n "${ondisk_manifest_path}" ]]; then
+                torcx_package_rootfs "${name}" "${version}" "${source_pkg}" "${tmppkgroot}" "squashfs" "${type}" "ondisk" "${ondisk_manifest_path}"
+        fi
+}
+
+function torcx_package_rootfs() {
+        local name="${1}"
+        local version="${2}"
+        local source_pkg="${3}"
+        local tmppkgroot="${4}"
+        local format="${5}"
+        local type="${6}"
+        local location="${7}"
+        local manifest_path="${8}"
+
+        local pkg_cas_file pkg_cas_root tmpfile sha512sum update_default digest
+        local pkg_locations=()
+
+        # create a tgz for the tectonic-torcx bucket for backwards
+        # compatibility reasons.
+        tmpfile="${BUILD_DIR}/${name}:${version}.torcx.${format}"
+        if [[ "${format}" == "tgz" ]]; then
+                tar --force-local -C "${tmppkgroot}" -czf "${tmpfile}" .
+        elif [[ "${format}" == "squashfs" ]]; then
+                mksquashfs "${tmppkgroot}" "${tmpfile}"
+        else
+                die "unrecognized format: ${format}"
+        fi
         sha512sum=$(sha512sum "${tmpfile}" | awk '{print $1}')
 
         # TODO(euank): this opaque digest, if it were reproducible, could save
@@ -188,24 +214,30 @@ function torcx_package() {
         # *MUST* ensure that a given pair of (digest, sha512sum) referenced in
         # a previous torcx package remains correct.
         # Because this code, as written, clobbers existing things with the same
-	# digest (but the sha512sum of the archive can differ, e.g. due to
-	# ctime) that property doesn't hold.
+        # digest (but the sha512sum of the archive can differ, e.g. due to
+        # ctime) that property doesn't hold.
         # To switch this back to a reprodicble digest, we *must* never clobber
         # existing objects (and thus re-use their sha512sum here).
         digest="${sha512sum}"
 
         pkg_cas_root="${TORCX_CAS_ROOT}/${name}/${digest}"
-        pkg_cas_file="${pkg_cas_root}/${name}:${version}.torcx.squashfs"
+        pkg_cas_file="${pkg_cas_root}/${name}:${version}.torcx.${format}"
         mkdir -p "${pkg_cas_root}"
         mv "${tmpfile}" "${pkg_cas_file}"
 
         update_default=false
         if [[ "${type}" == "default" ]]; then
                 update_default=true
-                pkg_locations+=("/usr/share/torcx/store/${name}:${version}.torcx.squashfs")
+                if [[ "${location}" == "ondisk" ]]; then
+                        pkg_locations+=("/usr/share/torcx/store/${name}:${version}.torcx.squashfs")
+                fi
         fi
-        if [[ "${FLAGS_upload}" -eq ${FLAGS_TRUE} ]]; then
-                pkg_locations+=("$(download_tectonic_torcx_url "pkgs/${BOARD}/${name}/${digest}/${name}:${version}.torcx.squashfs")")
+        if [[ "${FLAGS_upload}" -eq ${FLAGS_TRUE} ]] && [[ "${location}" == "remote" ]]; then
+                # HACK: this url location is wrong / unused in the case of
+                # format == squashfs during releases.
+                # Fortunately, the squashfs manifest is also not published
+                # publicly, but rather used for internal jenkins coordination
+                pkg_locations+=("$(download_tectonic_torcx_url "pkgs/${BOARD}/${name}/${digest}/${name}:${version}.torcx.${format}")")
         fi
         torcx_manifest::add_pkg "${manifest_path}" \
             "${name}" \
@@ -236,22 +268,46 @@ EXTRA_IMAGES=(
 )
 
 mkdir -p "${BUILD_DIR}"
-manifest_path="${BUILD_DIR}/torcx_manifest.json"
-torcx_manifest::create_empty "${manifest_path}"
-for pkg in "${@:-${DEFAULT_IMAGES[@]}}" ; do torcx_package "${pkg#=}" "${manifest_path}" "default" ; done
-for pkg in "${EXTRA_IMAGES[@]}" ; do torcx_package "${pkg#=}" "${manifest_path}" "extra" ; done
+remote_manifest_path="${BUILD_DIR}/torcx_manifest.json"
+# TODO: once 'torcx' includes tooling to manage a remote, this should be done using that tooling.
+# HACK: with the intrudction of squashfs, a second manifest was added. This
+# manifest is used for internal coordiation of what addons end up on disk in
+# the vendor store.
+# This no longer has the idea of a file that is at a tectonic-torcx usable url
+# and at an on-disk path. This is primarily because tectonic-torcx has
+# hardcoded '.tgz' in a few places.
+# However, tectonic-torcx does not assume that a 'path' field exists and should
+# operate fine without one, so this should let it keep on working.
+ondisk_manifest_path="${BUILD_DIR}/torcx_ondisk_manifest.json"
+torcx_manifest::create_empty "${remote_manifest_path}"
+torcx_manifest::create_empty "${ondisk_manifest_path}"
+for pkg in "${@:-${DEFAULT_IMAGES[@]}}" ; do torcx_package "${pkg#=}" "${remote_manifest_path}" "${ondisk_manifest_path}" "default" ; done
+# Extra packages aren't stored on disk, so we can skip passing in that manifest file
+for pkg in "${EXTRA_IMAGES[@]}" ; do torcx_package "${pkg#=}" "${remote_manifest_path}" "" "extra" ; done
 
 set_build_symlinks latest "${FLAGS_group}-latest"
 
 # Upload the pkgs referenced by this manifest
-for pkg in $(torcx_manifest::get_pkg_names "${manifest_path}"); do
-        for digest in $(torcx_manifest::get_digests "${manifest_path}" "${pkg}"); do
+for pkg in $(torcx_manifest::get_pkg_names "${remote_manifest_path}"); do
+        for digest in $(torcx_manifest::get_digests "${remote_manifest_path}" "${pkg}"); do
             # no need to sign; the manifest includes their shasum and is signed.
             upload_files \
                 'torcx pkg' \
                 "${TORCX_UPLOAD_ROOT}/pkgs/${BOARD}/${pkg}/${digest}" \
                 "" \
-                "${TORCX_CAS_ROOT}/${pkg}/${digest}"/*.torcx.squashfs
+                "${TORCX_CAS_ROOT}/${pkg}/${digest}"/*.torcx.*
+      done
+done
+
+# Upload ondisk files as well so that jenkins may re-use them between the build_packages and build_image steps
+for pkg in $(torcx_manifest::get_pkg_names "${ondisk_manifest_path}"); do
+        for digest in $(torcx_manifest::get_digests "${ondisk_manifest_path}" "${pkg}"); do
+            # no need to sign; the manifest includes their shasum and is signed.
+            upload_files \
+                'torcx pkg' \
+                "${TORCX_UPLOAD_ROOT}/pkgs/${BOARD}/${pkg}/${digest}" \
+                "" \
+                "${TORCX_CAS_ROOT}/${pkg}/${digest}"/*.torcx.*
       done
 done
 
@@ -264,9 +320,19 @@ done
 # final location, while the manifest still has to go through build bucket in
 # order to get signed.
 sign_and_upload_files \
-    'torcx manifest' \
+    'tectonic torcx manifest' \
     "${UPLOAD_ROOT}/torcx/manifests/${BOARD}/${COREOS_VERSION}" \
     "" \
-    "${manifest_path}"
+    "${remote_manifest_path}"
+
+# The squashfs_manifest is uploaded to the UPLOAD_ROOT, but never moved into
+# the TORCX_UPLOAD_ROOT due to jenkins not doing so; this is because
+# tectonic-torcx doesn't understand squashfs, but jenkins still needs to be
+# able to find squashfs archives to place in the rootfs
+sign_and_upload_files \
+    'torcx internal manifest' \
+    "${UPLOAD_ROOT}/torcx/manifests/${BOARD}/${COREOS_VERSION}" \
+    "" \
+    "${ondisk_manifest_path}"
 
 # vim: tabstop=8 softtabstop=4 shiftwidth=8 expandtab

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -55,7 +55,7 @@ do
         mkdir -p "torcx/pkgs/${BOARD}/${name}/${digest}"
         enter gsutil cp -r "${TORCX_PKG_DOWNLOAD_ROOT}/pkgs/${BOARD}/${name}/${digest}" \
             "/mnt/host/source/torcx/pkgs/${BOARD}/${name}/"
-        downloaded_hash=$(sha512sum "torcx/pkgs/${BOARD}/${name}/${digest}/"*.torcx.tgz | awk '{print $1}')
+        downloaded_hash=$(sha512sum "torcx/pkgs/${BOARD}/${name}/${digest}/"*.torcx.squashfs | awk '{print $1}')
         if [[ "sha512-${downloaded_hash}" != "${hash}" ]]
         then
                 echo "Torcx package had wrong hash: ${downloaded_hash} instead of ${hash}"


### PR DESCRIPTION
This can't be merged until the torcx binary in the image includes [squashfs support](https://github.com/coreos/torcx/pull/96).

This also is still WIP and may have some caveats.

The basic approach is to create both tgz and squashfs archives for anything included in the image, and just tgz for the ones that are only used by tectonic-torcx.
The build_image bit no longer includes the tgz files at all.

Everything else is juggling around files and code to try and make the above two statements true in a reasonable way.