### PR TITLE
build_torcx_store: bump docker to 18.05.0-r1

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -225,7 +225,7 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-18.05
+        =app-torcx/docker-18.05-r1
 )
 
 # This list contains extra images which will be uploaded and included in the


### PR DESCRIPTION
fixes https://github.com/coreos/bugs/issues/2440

Depends on https://github.com/coreos/coreos-overlay/pull/3243