### PR TITLE
transfer.sh: changes to updateservicectl usage for roller rollout strategies

### DIFF
--- a/offline_signing/transfer.sh
+++ b/offline_signing/transfer.sh
@@ -105,18 +105,17 @@ roll() {
             --server="https://public.update.core-os.net" \
             --user="${ROLLER_USERNAME}" \
             --key="${ROLLER_API_KEY}" \
-            group update \
+            group percent \
             --app-id="${APPID[${board}]}" \
             --group-id="${channel}" \
             --update-percent=100
     else
-        # TODO(sdemos): update this behavior when rollout strategies land in roller
         echo "Rollout set to 0%"
         updateservicectl \
             --server="https://public.update.core-os.net" \
             --user="${ROLLER_USERNAME}" \
             --key="${ROLLER_API_KEY}" \
-            group update \
+            group percent \
             --app-id="${APPID[${board}]}" \
             --group-id="${channel}" \
             --update-percent=0


### PR DESCRIPTION
This pr changes the update percent setting to use the new `group percent` `updateservicectl` command, and creates a new `transfer.sh` command call `roll` (the old `roll` is renamed to `ready`) which creates a linear rollout that reaches 100% in the provided number of seconds for each channel. `roll` only sets up a rollout for the amd64 application (the arm64 application is just set to 100% by default, so there is no need for a rollout).

 The old `roll` command, now called `ready`, sets the update percent for amd64 to 0% (and arm64 to 100%) and updates the channel to point at the provided package version. 

This is the only place in the scripts repo that needs to be updated for the new version of updateservicectl. It relies on the new version of updateservicectl to be in the sdk, and also relies on the new version of coreupdate to be deployed (it's not yet). 

cc: @bgilbert @dm0- @ajeddeloh 