### PR TITLE
catalyst: Temporarily disable update_seed

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -120,7 +120,7 @@ cat <<EOF
 target: stage1
 # stage1 packages aren't published, save in tmp
 pkgcache_path: ${TEMPDIR}/stage1-${ARCH}-packages
-update_seed: yes
+#update_seed: yes
 EOF
 catalyst_stage_default
 }


### PR DESCRIPTION
This can be reverted after switching to an SDK with Python 3.6 built into it.

Part of coreos/portage-stable#641