### PR TITLE
Revert "catalyst: Temporarily disable update_seed"

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -120,7 +120,7 @@ cat <<EOF
 target: stage1
 # stage1 packages aren't published, save in tmp
 pkgcache_path: ${TEMPDIR}/stage1-${ARCH}-packages
-#update_seed: yes
+update_seed: yes
 EOF
 catalyst_stage_default
 }


### PR DESCRIPTION
We now have an SDK with Python 3.6, so this isn't needed.

Part of coreos/coreos-overlay#3310