### PR TITLE
build_torcx_store: Stop building the old LTS image

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -232,7 +232,6 @@ DEFAULT_IMAGES=(
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
 	=app-torcx/docker-17.03
-	=app-torcx/docker-18.03
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
Part of coreos/coreos-overlay#3343