### PR TITLE
Drop /usr/include in beta

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -94,6 +94,7 @@ create_prod_image() {
   # clean-ups of things we do not need
   sudo rm ${root_fs_dir}/etc/csh.env
   sudo rm -rf ${root_fs_dir}/etc/env.d
+  sudo rm -rf ${root_fs_dir}/usr/include
   sudo rm -rf ${root_fs_dir}/var/db/pkg
 
   sudo mv ${root_fs_dir}/etc/profile.env \


### PR DESCRIPTION
This accidental directory hasn't made it to stable yet, so drop it before anyone starts using it.

Backports part of #846