### PR TITLE
backport "signing/sign.sh: fix armoring" to alpha

### DIFF
--- a/signing/sign.sh
+++ b/signing/sign.sh
@@ -56,7 +56,10 @@ fero-client \
 	--secret-key coreos-app-signing-key \
 	${torcx_signature_arg}
 gpg2 --enarmor \
-	--output "${DATA_DIR}/torcx_manifest.json.asc" \
-	"${DATA_DIR}/torcx_manifest.json.sig-fero"
+	--output - \
+	"${DATA_DIR}/torcx_manifest.json.sig-fero" \
+	| sed 's/ARMORED FILE/SIGNATURE/' \
+	> "${DATA_DIR}/torcx_manifest.json.asc"
+
 echo "=== Torcx manifest signed successfully. ==="
 rm -f "${DATA_DIR}/torcx_manifest.json.sig-fero"


### PR DESCRIPTION
We use gpg --enarmor to convert the torcx manifest binary sigs to ascii
armored ones. Unfortunately --enarmor just wraps the binary blob without
realizing its a signature, which breaks torcx. Pipe the output through
sed to fix the header.