### PR TITLE
build_torcx_store: Bump the default Docker to 19.03

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -238,7 +238,7 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-18.06
+        =app-torcx/docker-19.03
 )
 
 # This list contains extra images which will be uploaded and included in the


### PR DESCRIPTION
Part of coreos/coreos-overlay#3477