### PR TITLE
build_library: Drop whitelisted Go GLSAs

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -4,9 +4,6 @@
 
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
-	201710-23 # we handle Go differently; drop when 1.9 builds everything
-	201803-03 # same as above, drop when all Go < 1.9 packages are gone
-	201804-12 # same as above, except this requires only Go 1.10 or later
 	201810-10 # we fixed the systemd CVEs in 238, but this wants 239
 )
 


### PR DESCRIPTION
We could just whitelist `201812-09` like the others here, but Go is no longer built for the boards since coreos/coreos-overlay#3523, so there are no vulnerable versions found by the GLSA check.