### PR TITLE
catalyst: Temporarily disable update_seed again

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -120,7 +120,7 @@ cat <<EOF
 target: stage1
 # stage1 packages aren't published, save in tmp
 pkgcache_path: ${TEMPDIR}/stage1-${ARCH}-packages
-update_seed: yes
+update_seed: no
 EOF
 catalyst_stage_default
 }

--- a/build_library/check_root
+++ b/build_library/check_root
@@ -29,7 +29,8 @@ IGNORE_MISSING = {
                                  SonameAtom("x86_64", "libc.so.6")],
 
     # RPATHs and symlinks apparently confuse the perl-5.24 package
-    "dev-lang/perl":            [SonameAtom("x86_64", "libperl.so.5.24.1")],
+    "dev-lang/perl":            [SonameAtom("x86_64", "libperl.so.5.26.2")],
+    "sys-apps/texinfo":         [SonameAtom("x86_64", "libperl.so.5.26")],
 
     # https://bugs.gentoo.org/show_bug.cgi?id=554582
     "net-firewall/ebtables":    [SonameAtom("x86_64", "libebt_802_3.so"),


### PR DESCRIPTION
The Perl update will break SDK bootstrapping during seed update, so disable it again.  This can be reverted after bumping the SDK to a version that includes the new Perl.

Part of coreos/portage-stable#710