### PR TITLE
disk_util: Add -I for mkfs.vfat

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -420,7 +420,7 @@ def FormatFat(part, device):
   vfat_block_size = 1024
   vfat_blocks = part['bytes'] // vfat_block_size
 
-  cmd = ['mkfs.vfat']
+  cmd = ['mkfs.vfat', '-I']
   if 'fs_label' in part:
     cmd += ['-n', part['fs_label']]
   if part['type'] == 'efi':


### PR DESCRIPTION
When loop device partition nodes aren't cleaned up, building images will fail with:

    mkfs.vfat: Partitions or virtual mappings on device '/dev/loop0', not making filesystem (use -I to override)

Just add the flag unconditionally to work around it.