### PR TITLE
disk_util: Add -I for mkfs.vfat for 1967

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -420,7 +420,7 @@ def FormatFat(part, device):
   vfat_block_size = 1024
   vfat_blocks = part['bytes'] // vfat_block_size
 
-  cmd = ['mkfs.vfat']
+  cmd = ['mkfs.vfat', '-I']
   if 'fs_label' in part:
     cmd += ['-n', part['fs_label']]
   if part['type'] == 'efi':


### PR DESCRIPTION
Backport https://github.com/coreos/scripts/pull/864.