### PR TITLE
build_library: Drop whitelisted systemd GLSA

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -4,7 +4,6 @@
 
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
-	201810-10 # we fixed the systemd CVEs in 238, but this wants 239
 )
 
 glsa_image() {


### PR DESCRIPTION
This no longer matches since upgrading to 241.