### PR TITLE
jenkins: Free more disk space on successful job completion

### DIFF
--- a/jenkins/packages.sh
+++ b/jenkins/packages.sh
@@ -2,7 +2,7 @@
 
 # Use a ccache dir that persists across SDK recreations.
 # XXX: alternatively use a ccache dir that is usable by all jobs on a given node.
-mkdir -p .cache/ccache
+mkdir -p ccache
 
 enter() {
         local verify_key=
@@ -13,7 +13,7 @@ enter() {
         sudo ln -f "${GOOGLE_APPLICATION_CREDENTIALS}" \
             chroot/etc/portage/gangue.json
         bin/cork enter --bind-gpg-agent=false -- env \
-            CCACHE_DIR=/mnt/host/source/.cache/ccache \
+            CCACHE_DIR=/mnt/host/source/ccache \
             CCACHE_MAXSIZE=5G \
             COREOS_DEV_BUILDS="${DOWNLOAD_ROOT}" \
             {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get \

--- a/jenkins/sdk.sh
+++ b/jenkins/sdk.sh
@@ -20,6 +20,3 @@ enter sudo ${S}/bootstrap_sdk \
     --sign_digests="${SIGNING_USER}" \
     --upload_root="${UPLOAD_ROOT}" \
     --upload
-
-# Free some disk space only on success to allow debugging failures.
-sudo rm -rf src/build/catalyst/builds

--- a/jenkins/toolchains.sh
+++ b/jenkins/toolchains.sh
@@ -20,6 +20,3 @@ enter sudo ${S}/build_toolchains \
     --sign_digests="${SIGNING_USER}" \
     --upload_root="${UPLOAD_ROOT}" \
     --upload
-
-# Free some disk space only on success to allow debugging failures.
-sudo rm -rf src/build/catalyst/builds


### PR DESCRIPTION
This should make it safer for scheduling multiple runs on small workers without running out of disk space due to multiple workspaces having duplicate SDKs.