### PR TITLE
disk_layout: bump dev container from 3 to 4GB

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -131,7 +131,7 @@
         "label":"ROOT",
         "fs_label":"ROOT",
         "type":"4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
-        "blocks":"6291456"
+        "blocks":"8388608"
       }
     },
     "interoute":{


### PR DESCRIPTION
Builds are beginning to run out of space with 3GB. Bump to 4GB.