### PR TITLE
build_library: Add temporary workaround for binutils update

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -188,7 +188,7 @@ get_cross_pkgs() {
 }
 
 # Get portage arguments restricting toolchains to binary packages only.
-get_binonly_args() {
+get_binonly_args() { return ;
     local pkgs=( "${TOOLCHAIN_PKGS[@]}" $(get_cross_pkgs "$@") )
     echo "${pkgs[@]/#/--useoldpkg-atoms=}" "${pkgs[@]/#/--rebuild-exclude=}"
 }


### PR DESCRIPTION
Portage crashes trying to build the binutils security update.  This can be applied to produce a new SDK and toolchains binpkgs then reverted.

Part of coreos/portage-stable#738