### PR TITLE
Revert "build_library: Add temporary workaround for binutils update"

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -188,7 +188,7 @@ get_cross_pkgs() {
 }
 
 # Get portage arguments restricting toolchains to binary packages only.
-get_binonly_args() { return ;
+get_binonly_args() {
     local pkgs=( "${TOOLCHAIN_PKGS[@]}" $(get_cross_pkgs "$@") )
     echo "${pkgs[@]/#/--useoldpkg-atoms=}" "${pkgs[@]/#/--rebuild-exclude=}"
 }


### PR DESCRIPTION
Requires coreos/manifest#169