### PR TITLE
test_image_content: whitelist polkit GLSA

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -4,6 +4,7 @@
 
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
+	201908-14 # backported both CVE fixes
 )
 
 glsa_image() {


### PR DESCRIPTION
Both CVE fixes were backported.

Part of https://github.com/coreos/portage-stable/pull/742.