### PR TITLE
test_image_content: whitelist Perl and dbus GLSAs

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -5,6 +5,8 @@
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
 	201908-14 # backported both CVE fixes
+	201909-01 # Perl, SDK only
+	201909-08 # backported fix
 )
 
 glsa_image() {


### PR DESCRIPTION
Backported the dbus GLSA.  Ignoring the Perl one.

Part of https://github.com/coreos/coreos-overlay/pull/3761.