### PR TITLE
test_image_content: whitelist OpenSSH GLSA

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -7,6 +7,7 @@ GLSA_WHITELIST=(
 	201908-14 # backported both CVE fixes
 	201909-01 # Perl, SDK only
 	201909-08 # backported fix
+	201911-01 # package too old to even have the affected USE flag
 )
 
 glsa_image() {


### PR DESCRIPTION
It only affects a default-disabled USE flag, and our overlay ebuild is too old to even support it.

Part of https://github.com/coreos/coreos-overlay/pull/3803.