### PR TITLE
disk_util: retry loopback mounts if they fail on 2303

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -586,9 +586,22 @@ def Mount(options):
       mount_opts.append('subvol=%s' % mount['fs_subvolume'])
 
     Sudo(['mkdir', '-p', full_path])
-    Sudo(['mount', '-t', mount.get('fs_type', 'auto'),
-                   '-o', ','.join(mount_opts),
-                   options.disk_image, full_path])
+    # This tends to fail, retry if it does
+    err = None
+    for i in range(0,5):
+      try:
+        Sudo(['mount', '-t', mount.get('fs_type', 'auto'),
+                       '-o', ','.join(mount_opts),
+                       options.disk_image, full_path])
+        err = None
+        break
+      except subprocess.CalledProcessError as e:
+        print("Error mounting %s, attempt %d" % (full_path, i))
+        err = e
+        time.sleep(5)
+
+    if err is not None:
+      raise err
 
     for src, dst in mount.get('binds', {}).iteritems():
       # src may be relative or absolute, os.path.join handles this.


### PR DESCRIPTION
This fails frequently but should succeed if retried. This should reduce failed builds.