### PR TITLE
test_image_content: whitelist some GLSAs

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -8,6 +8,13 @@ GLSA_WHITELIST=(
 	201909-01 # Perl, SDK only
 	201909-08 # backported fix
 	201911-01 # package too old to even have the affected USE flag
+	202003-20 # backported fix
+	202003-12 # only applies to old, already-fixed CVEs
+	202003-24 # SDK only
+	202003-26 # SDK only
+	202003-30 # fixed by updating within older minor release
+	202003-31 # SDK only
+	202003-52 # difficult to update :-(
 )
 
 glsa_image() {


### PR DESCRIPTION
systemd and sudo are already fixed.  Git was fixed by updating to 2.23.2, not 2.24.1.  Samba is 2 years old and customized, thus difficult to update.  file, Python, and gdb are only in the SDK.

Part of https://github.com/coreos/portage-stable/pull/750.