### PR TITLE
test_image_content: whitelist some GLSAs

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -15,6 +15,9 @@ GLSA_WHITELIST=(
 	202003-30 # fixed by updating within older minor release
 	202003-31 # SDK only
 	202003-52 # difficult to update :-(
+	202004-13 # fixed by updating within older minor release
+	202005-02 # SDK only
+	202005-09 # SDK only
 )
 
 glsa_image() {


### PR DESCRIPTION
Git was fixed by updating to 2.23.3, not 2.26.2.  Python and QEMU are only in the SDK.

Part of https://github.com/coreos/portage-stable/pull/751.