### PR TITLE
test_image_content: whitelist OpenSSL GLSA

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -15,6 +15,7 @@ GLSA_WHITELIST=(
 	202003-30 # fixed by updating within older minor release
 	202003-31 # SDK only
 	202003-52 # difficult to update :-(
+	202004-10 # fixed by updating within older minor release
 	202004-13 # fixed by updating within older minor release
 	202005-02 # SDK only
 	202005-09 # SDK only


### PR DESCRIPTION
We updated to 1.0.2u instead of 1.1.1g.